### PR TITLE
Fix template bug in zabbix-server template with missing imagePullPolicy

### DIFF
--- a/charts/zabbix/Chart.yaml
+++ b/charts/zabbix/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2 # Don't change this
 name: zabbix
-version: 4.0.2 # helm chart version
+version: 4.0.3 # helm chart version
 # LTS Zabbix version by default due to stability. See: https://www.zabbix.com/life_cycle_and_release_policy
 appVersion: 6.0.20 # zabbix version
 description: Zabbix is a mature and effortless enterprise-class open source monitoring solution for network monitoring and application monitoring of millions of metrics.

--- a/charts/zabbix/README.md
+++ b/charts/zabbix/README.md
@@ -1,6 +1,6 @@
 # Helm chart for Zabbix.
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 4.0.2](https://img.shields.io/badge/Version-4.0.2-informational?style=flat-square)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 4.0.3](https://img.shields.io/badge/Version-4.0.3-informational?style=flat-square)
 
 Zabbix is a mature and effortless enterprise-class open source monitoring solution for network monitoring and application monitoring of millions of metrics.
 

--- a/charts/zabbix/artifacthub-pkg.yml
+++ b/charts/zabbix/artifacthub-pkg.yml
@@ -5,7 +5,7 @@
 # https://github.com/kedacore/external-scalers/blob/main/artifacthub/azure-cosmos-db/0.1.0/artifacthub-pkg.yml
 # https://artifacthub.io/packages/keda-scaler/keda-official-external-scalers/external-scaler-azure-cosmos-db?modal=install
 
-version: 4.0.2 # helm chart version
+version: 4.0.3 # helm chart version
 # LTS Zabbix version by default due to stability. See: https://www.zabbix.com/life_cycle_and_release_policy
 appVersion: 6.0.20 # zabbix version
 name: zabbix

--- a/charts/zabbix/templates/deployment-zabbix-server.yaml
+++ b/charts/zabbix/templates/deployment-zabbix-server.yaml
@@ -92,6 +92,7 @@ spec:
           {{- else }}
           image: "{{ .Values.zabbixServer.image.repository }}:{{ .Values.zabbixImageTag }}"
           {{- end }}
+          imagePullPolicy: {{ .Values.zabbixServer.image.pullPolicy }}
           ports:
             - containerPort: 10051
               name: zabbix-server


### PR DESCRIPTION
<!--
Thank you for contributing to this repository. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
the review guidelines form the Helm repository:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

I noticed when running [kube-score](https://github.com/zegl/kube-score) on a local deployment that the `imagePullPolicy` value is not included in the rendered manifest, as it is not actually included in the template for the zabbix-server Deployment. This is clearly an accidental omission, since it is already a documented feature.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

I have manually validated the change as follows, in addition to the checks documented in [CONTRIBUTING.md](https://github.com/zabbix-community/helm-zabbix/blob/master/CONTRIBUTING.md):

```bash
$ cd charts/zabbix
$ diff <(helm template .) <(helm template . --set zabbixServer.image.pullPolicy=Always)
21c21
<   password: "Qjl6MGtyR0VDZUdMVzBSVA=="
---
>   password: "bnBDT3V3djlPd0MzREtTMg=="
174c174
<           imagePullPolicy: IfNotPresent
---
>           imagePullPolicy: Always
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
