### PR TITLE
Add concurrencyPolicy value

### DIFF
--- a/charts/zabbix/templates/cronjob-hanodes-autoclean.yaml
+++ b/charts/zabbix/templates/cronjob-hanodes-autoclean.yaml
@@ -15,6 +15,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}-nodesclean
 spec:
   schedule: {{ .Values.zabbixServer.haNodesAutoClean.schedule|quote }}
+  concurrencyPolicy: {{ .Values.zabbixServer.haNodesAutoClean.concurrencyPolicy }}
   jobTemplate:
     spec:
       ttlSecondsAfterFinished: 86400

--- a/charts/zabbix/values.yaml
+++ b/charts/zabbix/values.yaml
@@ -88,6 +88,7 @@ zabbixServer:
       pullPolicy: IfNotPresent
       pullSecrets: []
     schedule: "0 1 * * *"
+    concurrencyPolicy: "Replace"
     deleteOlderThanSeconds: 3600
     # -- Extra environment variables. A list of additional environment variables.
     extraEnv: []


### PR DESCRIPTION
Hi,
I would like to add a value for concurrencyPolicy with `replace` by default.

Default value of [concurrencyPolicy](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#concurrency-policy) are `allow`, It's possible to have more than one cronjob run concurrently, for this job is not necessary.

Fixes #62 

David