### PR TITLE
Updates appVersion and image tag to latest 6.0.29

### DIFF
--- a/charts/zabbix/Chart.yaml
+++ b/charts/zabbix/Chart.yaml
@@ -1,9 +1,9 @@
 ---
 apiVersion: v2 # Don't change this
 name: zabbix
-version: 4.3.0 # helm chart version
+version: 4.4.0 # helm chart version
 # LTS Zabbix version by default due to stability. See: https://www.zabbix.com/life_cycle_and_release_policy
-appVersion: 6.0.27 # zabbix version
+appVersion: 6.0.29 # zabbix version
 description: Zabbix is a mature and effortless enterprise-class open source monitoring solution for network monitoring and application monitoring of millions of metrics.
 keywords:
   - zabbix

--- a/charts/zabbix/artifacthub-pkg.yml
+++ b/charts/zabbix/artifacthub-pkg.yml
@@ -5,13 +5,13 @@
 # https://github.com/kedacore/external-scalers/blob/main/artifacthub/azure-cosmos-db/0.1.0/artifacthub-pkg.yml
 # https://artifacthub.io/packages/keda-scaler/keda-official-external-scalers/external-scaler-azure-cosmos-db?modal=install
 
-version: 4.3.0 # helm chart version
+version: 4.4.0 # helm chart version
 # LTS Zabbix version by default due to stability. See: https://www.zabbix.com/life_cycle_and_release_policy
-appVersion: 6.0.27 # zabbix version
+appVersion: 6.0.29 # zabbix version
 name: zabbix
 category: monitoring, networking, metrics
 displayName: Zabbix - The Enterprise-Class Open Source Network Monitoring Solution
-createdAt: 2024-03-23T20:38:35Z # Command Linux: date +%Y-%m-%dT%TZ
+createdAt: 2024-05-09T11:58:53Z # Command Linux: date +%Y-%m-%dT%TZ
 description: Zabbix is a mature and effortless enterprise-class open source monitoring solution for network monitoring and application monitoring of millions of metrics.
 logoURL: https://assets.zabbix.com/img/logo/zabbix_logo_500x131.png
 license: Apache-2.0
@@ -53,7 +53,7 @@ install: |
   Set the helm chart version you want to use. Example:
 
   ```bash
-  export ZABBIX_CHART_VERSION='4.3.0'
+  export ZABBIX_CHART_VERSION='4.4.0'
   ```
 
   Export default values of ``zabbix`` chart to ``$HOME/zabbix_values.yaml`` file:

--- a/charts/zabbix/values.yaml
+++ b/charts/zabbix/values.yaml
@@ -20,7 +20,7 @@ global:
 #See more info in [Zabbix Life Cycle & Release Policy](https://www.zabbix.com/life_cycle_and_release_policy) page
 #When you want use a non-LTS version (example: 6.2.x), you have to set this yourself. You can change version
 #here or overwrite in each component (example: zabbixserver.image.tag, etc).
-zabbixImageTag: ubuntu-6.0.20
+zabbixImageTag: ubuntu-6.0.29
 
 # **Zabbix Postgresql access / credentials** configurations
 # with this dict, you can set unified PostgreSQL access credentials, IP and so on for both Zabbix Server and Zabbix web frontend


### PR DESCRIPTION
#### What this PR does / why we need it:
Updates appVersion and image tag to latest 6.0.29, and resolves mismatch between appversion and image tag

#### Which issue this PR fixes

  - fixes #87

#### Special notes for your reviewer:
no

#### Checklist

- [x] [DCO](https://github.com/zabbix-community/helm-zabbix/blob/master/CONTRIBUTING.md) signed
- [x] Chart Version bumped
