### PR TITLE
Add exteranlIPS and loadBalancerIP values to zabbix agent

### DIFF
--- a/charts/zabbix/README.md
+++ b/charts/zabbix/README.md
@@ -403,7 +403,9 @@ The following tables lists the configurable parameters of the chart and their de
 | zabbixAgent.securityContext | object | `{}` | Security Context configurations. Reference: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
 | zabbixAgent.service.annotations | object | `{}` | Annotations for the zabbix-agent service |
 | zabbixAgent.service.clusterIP | string | `nil` | Cluster IP for Zabbix Agent |
+| zabbixAgent.service.externalIPs | list | `[]` | IPs if use service type LoadBalancer" |
 | zabbixAgent.service.listenOnAllInterfaces | bool | `true` | externalTrafficPolicy for Zabbix Agent service. "Local" to preserve sender's IP address. Please note that this might not work on multi-node clusters, depending on your network settings. externalTrafficPolicy: Local |
+| zabbixAgent.service.loadBalancerIP | string | `""` |  |
 | zabbixAgent.service.port | int | `10050` | Port to expose service |
 | zabbixAgent.service.type | string | `"ClusterIP"` | Type of service for Zabbix Agent |
 | zabbixAgent.startupProbe | object | `{"failureThreshold":5,"initialDelaySeconds":15,"periodSeconds":5,"successThreshold":1,"tcpSocket":{"port":"zabbix-agent"},"timeoutSeconds":3}` | The kubelet uses startup probes to know when a container application has started.  Reference: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/ |

--- a/charts/zabbix/templates/service.yaml
+++ b/charts/zabbix/templates/service.yaml
@@ -67,6 +67,15 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.zabbixAgent.service.type }}
+  {{- if .Values.zabbixAgent.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.zabbixAgent.service.externalTrafficPolicy }}
+  {{- end }}
+  {{- if .Values.zabbixAgent.service.externalIPs }}
+  externalIPs: {{ .Values.zabbixAgent.service.externalIPs | toYaml | nindent 6 }}
+  {{- end }}
+  {{- if .Values.zabbixAgent.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.zabbixAgent.service.loadBalancerIP }}
+  {{- end }}
   {{- if .Values.zabbixAgent.service.clusterIP }}
   clusterIP: {{ .Values.zabbixAgent.service.clusterIP }}
   {{- end }}

--- a/charts/zabbix/values.yaml
+++ b/charts/zabbix/values.yaml
@@ -371,6 +371,11 @@ zabbixAgent:
   service:
     # -- Type of service for Zabbix Agent
     type: ClusterIP
+    # -- externalTrafficPolicy for Zabbix Agent. "Local" to preserve sender's IP address. Please note that this might not work on multi-node clusters, depending on your network settings.
+    #externalTrafficPolicy: Local
+    # -- IPs if use service type LoadBalancer"
+    externalIPs: []
+    loadBalancerIP: ""
     # -- Cluster IP for Zabbix Agent
     clusterIP:
     # -- Port to expose service


### PR DESCRIPTION
#### What this PR does / why we need it:
Zabbix agent running in cluster, but server is outside. This patch allow agent service set the ip address, if service type is loadbalance.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/zabbix-community/helm-zabbix/blob/master/CONTRIBUTING.md) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
