### PR TITLE
Upgrade Zabbix tag images to 6.0.30 and 6.4.15

### DIFF
--- a/charts/zabbix/Chart.yaml
+++ b/charts/zabbix/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2 # Don't change this
 name: zabbix
 version: 4.4.0 # helm chart version
 # LTS Zabbix version by default due to stability. See: https://www.zabbix.com/life_cycle_and_release_policy
-appVersion: 6.0.29 # zabbix version
+appVersion: 6.0.30 # zabbix version
 description: Zabbix is a mature and effortless enterprise-class open source monitoring solution for network monitoring and application monitoring of millions of metrics.
 keywords:
   - zabbix

--- a/charts/zabbix/README.md
+++ b/charts/zabbix/README.md
@@ -1,6 +1,6 @@
 # Helm chart for Zabbix.
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 4.3.0](https://img.shields.io/badge/Version-4.3.0-informational?style=flat-square)  [![Downloads](https://img.shields.io/github/downloads/zabbix-community/helm-zabbix/total?label=Downloads%20All%20Releases
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 4.4.0](https://img.shields.io/badge/Version-4.4.0-informational?style=flat-square)  [![Downloads](https://img.shields.io/github/downloads/zabbix-community/helm-zabbix/total?label=Downloads%20All%20Releases
 )](https://tooomm.github.io/github-release-stats/?username=zabbix-community&repository=helm-zabbix)
 
 Zabbix is a mature and effortless enterprise-class open source monitoring solution for network monitoring and application monitoring of millions of metrics.
@@ -410,7 +410,7 @@ The following tables lists the configurable parameters of the chart and their de
 | zabbixAgent.service.type | string | `"ClusterIP"` | Type of service for Zabbix Agent |
 | zabbixAgent.startupProbe | object | `{"failureThreshold":5,"initialDelaySeconds":15,"periodSeconds":5,"successThreshold":1,"tcpSocket":{"port":"zabbix-agent"},"timeoutSeconds":3}` | The kubelet uses startup probes to know when a container application has started.  Reference: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/ |
 | zabbixAgent.startupProbe.tcpSocket.port | string | `"zabbix-agent"` | Port number/alias name of the container |
-| zabbixImageTag | string | `"ubuntu-6.0.20"` | Zabbix components (server, agent, web frontend, ...) image tag to use. This helm chart is compatible with non-LTS version of Zabbix, that include important changes and functionalities. But by default this helm chart will install the latest LTS version (example: 6.0.x). See more info in [Zabbix Life Cycle & Release Policy](https://www.zabbix.com/life_cycle_and_release_policy) page When you want use a non-LTS version (example: 6.2.x), you have to set this yourself. You can change version here or overwrite in each component (example: zabbixserver.image.tag, etc). |
+| zabbixImageTag | string | `"ubuntu-6.0.30"` | Zabbix components (server, agent, web frontend, ...) image tag to use. This helm chart is compatible with non-LTS version of Zabbix, that include important changes and functionalities. But by default this helm chart will install the latest LTS version (example: 6.0.x). See more info in [Zabbix Life Cycle & Release Policy](https://www.zabbix.com/life_cycle_and_release_policy) page When you want use a non-LTS version (example: 6.2.x), you have to set this yourself. You can change version here or overwrite in each component (example: zabbixserver.image.tag, etc). |
 | zabbixJavaGateway.ZBX_DEBUGLEVEL | int | `3` | The variable is used to specify debug level, from 0 to 5 |
 | zabbixJavaGateway.ZBX_JAVAGATEWAY | string | `"zabbix-java-gateway"` | Additional arguments for Zabbix Java Gateway. Useful to enable additional libraries and features. ZABBIX_OPTIONS:  Java Gateway Service Name |
 | zabbixJavaGateway.ZBX_START_POLLERS | int | `5` | This variable is specified amount of pollers. By default, value is 5 |

--- a/charts/zabbix/artifacthub-pkg.yml
+++ b/charts/zabbix/artifacthub-pkg.yml
@@ -7,11 +7,11 @@
 
 version: 4.4.0 # helm chart version
 # LTS Zabbix version by default due to stability. See: https://www.zabbix.com/life_cycle_and_release_policy
-appVersion: 6.0.29 # zabbix version
+appVersion: 6.0.30 # zabbix version
 name: zabbix
 category: monitoring, networking, metrics
 displayName: Zabbix - The Enterprise-Class Open Source Network Monitoring Solution
-createdAt: 2024-05-09T11:58:53Z # Command Linux: date +%Y-%m-%dT%TZ
+createdAt: 2024-05-22T01:57:26Z # Command Linux: date +%Y-%m-%dT%TZ
 description: Zabbix is a mature and effortless enterprise-class open source monitoring solution for network monitoring and application monitoring of millions of metrics.
 logoURL: https://assets.zabbix.com/img/logo/zabbix_logo_500x131.png
 license: Apache-2.0

--- a/charts/zabbix/docs/example/kind/values.yaml
+++ b/charts/zabbix/docs/example/kind/values.yaml
@@ -1,6 +1,6 @@
 # Custom values for zabbix.
 
-zabbixImageTag: 6.4.12-alpine
+zabbixImageTag: 6.4.15-alpine
 
 postgresAccess:
   useUnifiedSecret: true

--- a/charts/zabbix/values.yaml
+++ b/charts/zabbix/values.yaml
@@ -20,7 +20,7 @@ global:
 #See more info in [Zabbix Life Cycle & Release Policy](https://www.zabbix.com/life_cycle_and_release_policy) page
 #When you want use a non-LTS version (example: 6.2.x), you have to set this yourself. You can change version
 #here or overwrite in each component (example: zabbixserver.image.tag, etc).
-zabbixImageTag: ubuntu-6.0.29
+zabbixImageTag: ubuntu-6.0.30
 
 # **Zabbix Postgresql access / credentials** configurations
 # with this dict, you can set unified PostgreSQL access credentials, IP and so on for both Zabbix Server and Zabbix web frontend


### PR DESCRIPTION
#### What this PR does / why we need it:

Upgrade Zabbix tag images to 6.0.30 and 6.4.15
Bump chart version
Update documentation

#### Checklist
- [x] [DCO](https://github.com/zabbix-community/helm-zabbix/blob/master/CONTRIBUTING.md) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
