### PR TITLE
Add envfrom parameters

### DIFF
--- a/charts/zabbix/README.md
+++ b/charts/zabbix/README.md
@@ -333,6 +333,7 @@ The following tables lists the configurable parameters of the chart and their de
 | postgresql.containerAnnotations | object | `{}` | Annotations to add to the containers |
 | postgresql.containerLabels | object | `{}` | Labels to add to the containers |
 | postgresql.enabled | bool | `true` | Create a database using Postgresql |
+| postgresql.envFrom | list | `[]` | Extra environment variables from secrets or configmaps |
 | postgresql.extraContainers | list | `[]` | Additional containers to start within the postgresql pod |
 | postgresql.extraEnv | list | `[]` | Extra environment variables. A list of additional environment variables. |
 | postgresql.extraInitContainers | list | `[]` | Additional init containers to start within the postgresql pod |
@@ -383,6 +384,7 @@ The following tables lists the configurable parameters of the chart and their de
 | zabbixAgent.daemonSetLabels | object | `{}` | Labels to add to the daemonSet |
 | zabbixAgent.deploymentLabels | object | `{}` | Labels to add to the deployment |
 | zabbixAgent.enabled | bool | `true` | Enables use of **Zabbix Agent** |
+| zabbixAgent.envFrom | list | `[]` | Extra environment variables from secrets or configmaps |
 | zabbixAgent.extraContainers | list | `[]` | Additional containers to start within the Zabbix Agent pod |
 | zabbixAgent.extraEnv | list | `[]` | Extra environment variables. A list of additional environment variables. List can be extended with other environment variables listed here: https://github.com/zabbix/zabbix-docker/tree/6.0/Dockerfiles/agent2/alpine#environment-variables. See example: https://github.com/zabbix-community/helm-zabbix/blob/master/charts/zabbix/docs/example/kind/values.yaml |
 | zabbixAgent.extraInitContainers | list | `[]` | Additional init containers to start within the Zabbix Agent pod |
@@ -420,6 +422,7 @@ The following tables lists the configurable parameters of the chart and their de
 | zabbixJavaGateway.deploymentAnnotations | object | `{}` | Annotations to add to the deployment |
 | zabbixJavaGateway.deploymentLabels | object | `{}` | Labels to add to the deployment |
 | zabbixJavaGateway.enabled | bool | `false` | Enables use of **Zabbix Java Gateway** |
+| zabbixJavaGateway.envFrom | list | `[]` | Extra environment variables from secrets or configmaps |
 | zabbixJavaGateway.extraContainers | list | `[]` | Additional containers to start within the Zabbix Java Gateway pod |
 | zabbixJavaGateway.extraEnv | list | `[]` | Extra environment variables. A list of additional environment variables. List can be extended with other environment variables listed here: https://github.com/zabbix/zabbix-docker/tree/6.0/Dockerfiles/agent2/alpine#environment-variables. See example: https://github.com/zabbix-community/helm-zabbix/blob/master/charts/zabbix/docs/example/kind/values.yaml |
 | zabbixJavaGateway.extraInitContainers | list | `[]` | Additional init containers to start within the Zabbix Java Gateway pod |
@@ -454,6 +457,7 @@ The following tables lists the configurable parameters of the chart and their de
 | zabbixProxy.containerAnnotations | object | `{}` | Annotations to add to the containers |
 | zabbixProxy.containerLabels | object | `{}` | Labels to add to the containers |
 | zabbixProxy.enabled | bool | `false` | Enables use of **Zabbix Proxy** |
+| zabbixProxy.envFrom | list | `[]` | Extra environment variables from secrets or configmaps |
 | zabbixProxy.extraContainers | list | `[]` | Additional containers to start within the Zabbix Proxy pod |
 | zabbixProxy.extraEnv | list | `[]` | Extra environment variables. A list of additional environment variables. List can be extended with other environment variables listed here: https://github.com/zabbix/zabbix-docker/tree/6.0/Dockerfiles/proxy-sqlite3/alpine#environment-variables. See example: https://github.com/zabbix-community/helm-zabbix/blob/master/charts/zabbix/docs/example/kind/values.yaml |
 | zabbixProxy.extraInitContainers | list | `[]` | Additional init containers to start within the Zabbix Proxy pod |
@@ -482,14 +486,16 @@ The following tables lists the configurable parameters of the chart and their de
 | zabbixServer.deploymentAnnotations | object | `{}` | Annotations to add to the deployment |
 | zabbixServer.deploymentLabels | object | `{}` | Labels to add to the deployment |
 | zabbixServer.enabled | bool | `true` | Enables use of **Zabbix Server** |
+| zabbixServer.envFrom | list | `[]` | Extra environment variables from secrets or configmaps |
 | zabbixServer.extraContainers | list | `[]` | Additional containers to start within the Zabbix Server pod |
 | zabbixServer.extraEnv | list | `[]` | Extra environment variables. A list of additional environment variables. List can be extended with other environment variables listed here: https://github.com/zabbix/zabbix-docker/tree/6.0/Dockerfiles/server-pgsql/alpine#environment-variables. See example: https://github.com/zabbix-community/helm-zabbix/blob/master/charts/zabbix/docs/example/kind/values.yaml |
 | zabbixServer.extraInitContainers | list | `[]` | Additional init containers to start within the Zabbix Server pod |
 | zabbixServer.extraPodSpecs | object | `{}` | Additional specifications to the Zabbix Server pod |
 | zabbixServer.extraVolumeMounts | list | `[]` | Additional volumeMounts to the Zabbix Server container |
 | zabbixServer.extraVolumes | list | `[]` | Additional volumes to make available to the Zabbix Server pod |
-| zabbixServer.haNodesAutoClean | object | `{"concurrencyPolicy":"Replace","cronjobLabels":{},"deleteOlderThanSeconds":3600,"enabled":true,"extraContainers":[],"extraEnv":[],"extraInitContainers":[],"extraPodSpecs":{},"extraVolumeMounts":[],"extraVolumes":[],"image":{"pullPolicy":"IfNotPresent","pullSecrets":[],"repository":"postgres","tag":15},"resources":{},"schedule":"0 1 * * *","securityContext":{}}` | Automatically clean orphaned ha nodes from ha_nodes db table |
+| zabbixServer.haNodesAutoClean | object | `{"concurrencyPolicy":"Replace","cronjobLabels":{},"deleteOlderThanSeconds":3600,"enabled":true,"envFrom":[],"extraContainers":[],"extraEnv":[],"extraInitContainers":[],"extraPodSpecs":{},"extraVolumeMounts":[],"extraVolumes":[],"image":{"pullPolicy":"IfNotPresent","pullSecrets":[],"repository":"postgres","tag":15},"resources":{},"schedule":"0 1 * * *","securityContext":{}}` | Automatically clean orphaned ha nodes from ha_nodes db table |
 | zabbixServer.haNodesAutoClean.cronjobLabels | object | `{}` | Labels to add to the cronjob for ha nodes autoclean |
+| zabbixServer.haNodesAutoClean.envFrom | list | `[]` | Extra environment variables from secrets or configmaps |
 | zabbixServer.haNodesAutoClean.extraContainers | list | `[]` | Additional containers to start within the cronjob hanodes autoclean |
 | zabbixServer.haNodesAutoClean.extraEnv | list | `[]` | Extra environment variables. A list of additional environment variables. |
 | zabbixServer.haNodesAutoClean.extraInitContainers | list | `[]` | Additional init containers to start within the cronjob hanodes autoclean |
@@ -533,6 +539,7 @@ The following tables lists the configurable parameters of the chart and their de
 | zabbixWeb.deploymentAnnotations | object | `{}` | Annotations to add to the deployment |
 | zabbixWeb.deploymentLabels | object | `{}` | Labels to add to the deployment |
 | zabbixWeb.enabled | bool | `true` | Enables use of **Zabbix Web** |
+| zabbixWeb.envFrom | list | `[]` | Extra environment variables from secrets or configmaps |
 | zabbixWeb.extraContainers | list | `[]` | Additional containers to start within the Zabbix Web pod |
 | zabbixWeb.extraEnv | list | `[]` | Extra environment variables. A list of additional environment variables. List can be extended with other environment variables listed here: https://github.com/zabbix/zabbix-docker/tree/6.0/Dockerfiles/web-apache-pgsql/alpine#environment-variables. See example: https://github.com/zabbix-community/helm-zabbix/blob/master/charts/zabbix/docs/example/kind/values.yaml |
 | zabbixWeb.extraInitContainers | list | `[]` | Additional init containers to start within the Zabbix Web pod |
@@ -573,6 +580,7 @@ The following tables lists the configurable parameters of the chart and their de
 | zabbixWebService.deploymentAnnotations | object | `{}` | Annotations to add to the deployment |
 | zabbixWebService.deploymentLabels | object | `{}` | Labels to add to the deployment |
 | zabbixWebService.enabled | bool | `true` | Enables use of **Zabbix Web Service** |
+| zabbixWebService.envFrom | list | `[]` | Extra environment variables from secrets or configmaps |
 | zabbixWebService.extraContainers | list | `[]` | Additional containers to start within the Zabbix Web Service pod |
 | zabbixWebService.extraEnv | list | `[]` | Extra environment variables. A list of additional environment variables. List can be extended with other environment variables listed here: https://github.com/zabbix/zabbix-docker/tree/6.0/Dockerfiles/web-service/alpine#environment-variables. See example: https://github.com/zabbix-community/helm-zabbix/blob/master/charts/zabbix/docs/example/kind/values.yaml |
 | zabbixWebService.extraInitContainers | list | `[]` | Additional init containers to start within the Zabbix Web Service pod |

--- a/charts/zabbix/templates/cronjob-hanodes-autoclean.yaml
+++ b/charts/zabbix/templates/cronjob-hanodes-autoclean.yaml
@@ -65,6 +65,10 @@ spec:
             - name: {{ $item.name }}
               value: {{ $item.value | quote }}
             {{- end }}
+            {{- with .Values.zabbixServer.haNodesAutoClean.envFrom }}
+            envFrom:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
             {{- with .Values.zabbixServer.haNodesAutoClean.extraVolumeMounts }}
             volumeMounts:
               {{- toYaml . | nindent 14 }}

--- a/charts/zabbix/templates/daemonset-zabbix-agent.yaml
+++ b/charts/zabbix/templates/daemonset-zabbix-agent.yaml
@@ -116,6 +116,10 @@ spec:
             - name: {{ $item.name }}
               value: {{ $item.value | quote }}
             {{- end }}
+          {{- with .Values.zabbixAgent.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: proc
               mountPath: /hostfs/proc

--- a/charts/zabbix/templates/deployment-zabbix-java-gateway.yaml
+++ b/charts/zabbix/templates/deployment-zabbix-java-gateway.yaml
@@ -119,6 +119,10 @@ spec:
             - name: {{ $item.name }}
               value: {{ $item.value | quote }}
             {{- end }}
+          {{- with .Values.zabbixJavaGateway.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.zabbixJavaGateway.extraVolumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}

--- a/charts/zabbix/templates/deployment-zabbix-server.yaml
+++ b/charts/zabbix/templates/deployment-zabbix-server.yaml
@@ -160,6 +160,10 @@ spec:
             - name: ZBX_STARTJAVAPOLLERS
               value: {{ .Values.zabbixJavaGateway.ZBX_STARTJAVAPOLLERS | quote }}
             {{- end }}
+          {{- with .Values.zabbixServer.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.zabbixServer.extraVolumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}
@@ -213,6 +217,10 @@ spec:
             - name: {{ $item.name }}
               value: {{ $item.value | quote }}
             {{- end }}
+          {{- with .Values.zabbixAgent.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: zabbix-agent
               containerPort: 10050

--- a/charts/zabbix/templates/deployment-zabbix-web.yaml
+++ b/charts/zabbix/templates/deployment-zabbix-web.yaml
@@ -92,6 +92,10 @@ spec:
           - name: {{ $item.name }}
             value: {{ $item.value | quote }}
           {{- end }}
+        {{- with .Values.zabbixWeb.envFrom }}
+        envFrom:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         ports:
           - name: zabbix-web
             containerPort: 8080

--- a/charts/zabbix/templates/deployment-zabbix-webservice.yaml
+++ b/charts/zabbix/templates/deployment-zabbix-webservice.yaml
@@ -97,6 +97,10 @@ spec:
           {{- end }}
           - name: ZBX_ALLOWEDIP
             value: "::/0"
+        {{- with .Values.zabbixWebService.envFrom }}
+        envFrom:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         ports:
           - name: webservice
             containerPort: 10053

--- a/charts/zabbix/templates/job-init-db-schema.yaml
+++ b/charts/zabbix/templates/job-init-db-schema.yaml
@@ -83,6 +83,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
+        {{- with .Values.zabbixServer.envFrom }}
+        envFrom:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         {{- with .Values.zabbixServer.jobDBSchema.extraVolumeMounts }}
         volumeMounts:
           {{- toYaml . | nindent 10 }}

--- a/charts/zabbix/templates/statefulset-postgresql.yaml
+++ b/charts/zabbix/templates/statefulset-postgresql.yaml
@@ -109,6 +109,10 @@ spec:
             - name: {{ $item.name }}
               value: {{ $item.value | quote }}
             {{- end }}
+          {{- with .Values.postgresql.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
           {{- if .Values.postgresql.persistence.enabled }}
             - name: postgresql-data

--- a/charts/zabbix/templates/statefulset-zabbix-proxy.yaml
+++ b/charts/zabbix/templates/statefulset-zabbix-proxy.yaml
@@ -116,6 +116,10 @@ spec:
             - name: {{ $item.name }}
               value: {{ $item.value | quote }}
             {{- end }}
+          {{- with .Values.zabbixAgent.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: zabbix-agent
               containerPort: 10050

--- a/charts/zabbix/values.yaml
+++ b/charts/zabbix/values.yaml
@@ -104,6 +104,8 @@ zabbixServer:
     deleteOlderThanSeconds: 3600
     # -- Requests and limits of pod resources. See: [https://kubernetes.io/docs/concepts/configuration/manage-resources-containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers)
     resources: {}
+    # -- Extra environment variables from secrets or configmaps
+    envFrom: []
     # -- Extra environment variables. A list of additional environment variables.
     extraEnv: []
     # -- Additional volumeMounts to the cronjob hanodes autoclean
@@ -154,6 +156,8 @@ zabbixServer:
     # -- Annotations for the zabbix-server service
     annotations: {}
     # metallb.universe.tf/address-pool: production-public-ips
+  # -- Extra environment variables from secrets or configmaps
+  envFrom: []
   # -- Extra environment variables. A list of additional environment variables. List can be extended with other environment variables listed here: https://github.com/zabbix/zabbix-docker/tree/6.0/Dockerfiles/server-pgsql/alpine#environment-variables. See example: https://github.com/zabbix-community/helm-zabbix/blob/master/charts/zabbix/docs/example/kind/values.yaml
   extraEnv: []
   #- name: ENABLE_TIMESCALEDB
@@ -226,6 +230,8 @@ postgresql:
   # -- Extra Postgresql runtime parameters ("-c" options)
   extraRuntimeParameters:
     max_connections: 50
+  # -- Extra environment variables from secrets or configmaps
+  envFrom: []
   # -- Extra environment variables. A list of additional environment variables.
   extraEnv: []
   # -- Annotations to add to the statefulset
@@ -300,6 +306,8 @@ zabbixProxy:
     # -- Annotations for the zabbix-proxy service
     annotations: {}
     # metallb.universe.tf/address-pool: production-public-ips
+  # -- Extra environment variables from secrets or configmaps
+  envFrom: []
   # -- Extra environment variables. A list of additional environment variables. List can be extended with other environment variables listed here: https://github.com/zabbix/zabbix-docker/tree/6.0/Dockerfiles/proxy-sqlite3/alpine#environment-variables. See example: https://github.com/zabbix-community/helm-zabbix/blob/master/charts/zabbix/docs/example/kind/values.yaml
   extraEnv: []
   # -- Annotations to add to the statefulset
@@ -390,6 +398,8 @@ zabbixAgent:
     # metallb.universe.tf/address-pool: production-public-ips
   # -- If true, agent pods mounts host / at /host/root
   hostRootFsMount: true
+  # -- Extra environment variables from secrets or configmaps
+  envFrom: []
   # -- Extra environment variables. A list of additional environment variables. List can be extended with other environment variables listed here: https://github.com/zabbix/zabbix-docker/tree/6.0/Dockerfiles/agent2/alpine#environment-variables. See example: https://github.com/zabbix-community/helm-zabbix/blob/master/charts/zabbix/docs/example/kind/values.yaml
   extraEnv: []
   # -- Additional volumeMounts to the zabbix Agent container
@@ -474,6 +484,8 @@ zabbixWeb:
     # -- Annotations for the Zabbix Web
     annotations: {}
     # metallb.universe.tf/address-pool: production-public-ips
+  # -- Extra environment variables from secrets or configmaps
+  envFrom: []
   # -- Extra environment variables. A list of additional environment variables. List can be extended with other environment variables listed here: https://github.com/zabbix/zabbix-docker/tree/6.0/Dockerfiles/web-apache-pgsql/alpine#environment-variables. See example: https://github.com/zabbix-community/helm-zabbix/blob/master/charts/zabbix/docs/example/kind/values.yaml
   extraEnv: []
   #- name: ZBX_SSO_SETTINGS
@@ -556,6 +568,8 @@ zabbixWebService:
     # -- Annotations for the Zabbix Web Service
     annotations: {}
     # metallb.universe.tf/address-pool: production-public-ips
+  # -- Extra environment variables from secrets or configmaps
+  envFrom: []
   # -- Extra environment variables. A list of additional environment variables. List can be extended with other environment variables listed here: https://github.com/zabbix/zabbix-docker/tree/6.0/Dockerfiles/web-service/alpine#environment-variables. See example: https://github.com/zabbix-community/helm-zabbix/blob/master/charts/zabbix/docs/example/kind/values.yaml
   extraEnv: []
   # -- Annotations to add to the deployment
@@ -630,6 +644,8 @@ zabbixJavaGateway:
     # -- Annotations for the zabbix-java-gateway service
     annotations: {}
     # metallb.universe.tf/address-pool: production-public-ips
+  # -- Extra environment variables from secrets or configmaps
+  envFrom: []
   # -- Extra environment variables. A list of additional environment variables. List can be extended with other environment variables listed here: https://github.com/zabbix/zabbix-docker/tree/6.0/Dockerfiles/agent2/alpine#environment-variables. See example: https://github.com/zabbix-community/helm-zabbix/blob/master/charts/zabbix/docs/example/kind/values.yaml
   extraEnv: []
   # -- Additional volumeMounts to the Zabbix Java Gateway container


### PR DESCRIPTION
#### What this PR does / why we need it:
Allow extra environment variables from secrets or configmaps. 

(my usecase: added custom userparameters, which use some passwords. This password can set from secrets with env)

#### Special notes for your reviewer:
I hesitated the right variable name (_envFrom_ vs _extraEnvFrom_). i checked some other helm charts, and more use _envFrom_ names.
like [traefik](https://github.com/traefik/traefik-helm-chart/blob/master/traefik/values.yaml#L603), [filebeat](https://github.com/elastic/helm-charts/blob/main/filebeat/values.yaml#L11) (with _extraEnvs_ and _extraVolumes_).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/zabbix-community/helm-zabbix/blob/master/CONTRIBUTING.md) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
