### PR TITLE
Improvements in services templates of Zabbix components

### DIFF
--- a/charts/zabbix/Chart.yaml
+++ b/charts/zabbix/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2 # Don't change this
 name: zabbix
-version: 4.4.0 # helm chart version
+version: 4.4.1 # helm chart version
 # LTS Zabbix version by default due to stability. See: https://www.zabbix.com/life_cycle_and_release_policy
 appVersion: 6.0.30 # zabbix version
 description: Zabbix is a mature and effortless enterprise-class open source monitoring solution for network monitoring and application monitoring of millions of metrics.

--- a/charts/zabbix/README.md
+++ b/charts/zabbix/README.md
@@ -1,6 +1,6 @@
 # Helm chart for Zabbix.
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 4.4.0](https://img.shields.io/badge/Version-4.4.0-informational?style=flat-square)  [![Downloads](https://img.shields.io/github/downloads/zabbix-community/helm-zabbix/total?label=Downloads%20All%20Releases
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 4.4.1](https://img.shields.io/badge/Version-4.4.1-informational?style=flat-square)  [![Downloads](https://img.shields.io/github/downloads/zabbix-community/helm-zabbix/total?label=Downloads%20All%20Releases
 )](https://tooomm.github.io/github-release-stats/?username=zabbix-community&repository=helm-zabbix)
 
 Zabbix is a mature and effortless enterprise-class open source monitoring solution for network monitoring and application monitoring of millions of metrics.
@@ -43,7 +43,7 @@ helm search repo zabbix-community/zabbix -l
 Set the helm chart version you want to use. Example:
 
 ```bash
-export ZABBIX_CHART_VERSION='4.4.0'
+export ZABBIX_CHART_VERSION='4.4.1'
 ```
 
 Export default values of ``zabbix`` chart to ``$HOME/zabbix_values.yaml`` file:
@@ -352,9 +352,9 @@ The following tables lists the configurable parameters of the chart and their de
 | postgresql.resources | object | `{}` | Requests and limits of pod resources. See: [https://kubernetes.io/docs/concepts/configuration/manage-resources-containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers) |
 | postgresql.securityContext | object | `{}` | Security Context configurations. Reference: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
 | postgresql.service.annotations | object | `{}` | Annotations for the zabbix-server service |
-| postgresql.service.clusterIP | string | `nil` | Cluster IP for Zabbix Server |
+| postgresql.service.clusterIP | string | `nil` | clusterIP is the IP address of the service and is usually assigned randomly. If an address is specified manually,  is in-range (as per system configuration), and is not in use, it will be allocated to the service. |
 | postgresql.service.port | int | `5432` | Port of service in Kubernetes cluster |
-| postgresql.service.type | string | `"ClusterIP"` | Type of service in Kubernetes cluster |
+| postgresql.service.type | string | `"ClusterIP"` | Type of service to expose the application. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. More details: https://kubernetes.io/docs/concepts/services-networking/service/ |
 | postgresql.startupProbe | object | `{}` | The kubelet uses startup probes to know when a container application has started.  Reference: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/ |
 | postgresql.statefulSetAnnotations | object | `{}` | Annotations to add to the statefulset |
 | postgresql.statefulSetLabels | object | `{}` | Labels to add to the statefulset |
@@ -402,12 +402,15 @@ The following tables lists the configurable parameters of the chart and their de
 | zabbixAgent.runAsSidecar | bool | `true` | Its is a default mode. Zabbix-agent will run as sidecar in zabbix-server and zabbix-proxy pods. Disable this mode if you want to run zabbix-agent as daemonSet |
 | zabbixAgent.securityContext | object | `{}` | Security Context configurations. Reference: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
 | zabbixAgent.service.annotations | object | `{}` | Annotations for the zabbix-agent service |
-| zabbixAgent.service.clusterIP | string | `nil` | Cluster IP for Zabbix Agent |
-| zabbixAgent.service.externalIPs | list | `[]` | IPs if use service type LoadBalancer" |
-| zabbixAgent.service.listenOnAllInterfaces | bool | `true` | externalTrafficPolicy for Zabbix Agent service. "Local" to preserve sender's IP address. Please note that this might not work on multi-node clusters, depending on your network settings. externalTrafficPolicy: Local |
-| zabbixAgent.service.loadBalancerIP | string | `""` |  |
-| zabbixAgent.service.port | int | `10050` | Port to expose service |
-| zabbixAgent.service.type | string | `"ClusterIP"` | Type of service for Zabbix Agent |
+| zabbixAgent.service.clusterIP | string | `nil` | clusterIP is the IP address of the service and is usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service. |
+| zabbixAgent.service.externalIPs | list | `[]` | externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.  These IPs are not managed by Kubernetes. |
+| zabbixAgent.service.loadBalancerClass | string | `""` | loadBalancerClass is the class of the load balancer implementation this Service belongs to.  If specified, the value of this field must be a label-style identifier, with an optional prefix, e.g. "internal-vip" or  "example.com/internal-vip". Unprefixed names are reserved for end-users. This field can only be set when the Service type is 'LoadBalancer'.  If not set, the default load balancer implementation is used, today this is typically done through the cloud provider integration,  but should apply for any default implementation. If set, it is assumed that a load balancer implementation is watching for Services  with a matching class. Any default load balancer implementation (e.g. cloud providers) should ignore Services that set this field.  This field can only be set when creating or updating a Service to type 'LoadBalancer'. Once set, it can not be changed.  This field will be wiped when a service is updated to a non 'LoadBalancer' type. |
+| zabbixAgent.service.loadBalancerIP | string | `""` | Only applies to Service Type: LoadBalancer. This feature depends on whether the underlying cloud-provider supports specifying  the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature. |
+| zabbixAgent.service.loadBalancerSourceRanges | list | `[]` | If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer  will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature. |
+| zabbixAgent.service.nodePort | int | `31050` | NodePort port to allocate on each node (only if service.type = NodePort or Loadbalancer) |
+| zabbixAgent.service.port | int | `10050` | Port of service in Kubernetes cluster |
+| zabbixAgent.service.sessionAffinity | string | `"None"` | Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity.  Must be ClientIP or None. Defaults to None. More info:  https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies |
+| zabbixAgent.service.type | string | `"ClusterIP"` | Type of service to expose the application. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer.  More details: https://kubernetes.io/docs/concepts/services-networking/service/ |
 | zabbixAgent.startupProbe | object | `{"failureThreshold":5,"initialDelaySeconds":15,"periodSeconds":5,"successThreshold":1,"tcpSocket":{"port":"zabbix-agent"},"timeoutSeconds":3}` | The kubelet uses startup probes to know when a container application has started.  Reference: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/ |
 | zabbixAgent.startupProbe.tcpSocket.port | string | `"zabbix-agent"` | Port number/alias name of the container |
 | zabbixImageTag | string | `"ubuntu-6.0.30"` | Zabbix components (server, agent, web frontend, ...) image tag to use. This helm chart is compatible with non-LTS version of Zabbix, that include important changes and functionalities. But by default this helm chart will install the latest LTS version (example: 6.0.x). See more info in [Zabbix Life Cycle & Release Policy](https://www.zabbix.com/life_cycle_and_release_policy) page When you want use a non-LTS version (example: 6.2.x), you have to set this yourself. You can change version here or overwrite in each component (example: zabbixserver.image.tag, etc). |
@@ -437,10 +440,15 @@ The following tables lists the configurable parameters of the chart and their de
 | zabbixJavaGateway.resources | object | `{}` | Requests and limits of pod resources. See: [https://kubernetes.io/docs/concepts/configuration/manage-resources-containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers) |
 | zabbixJavaGateway.securityContext | object | `{}` | Security Context configurations. Reference: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
 | zabbixJavaGateway.service.annotations | object | `{}` | Annotations for the zabbix-java-gateway service |
-| zabbixJavaGateway.service.clusterIP | string | `nil` | Cluster IP for Zabbix Java Gateway |
-| zabbixJavaGateway.service.listenOnAllInterfaces | bool | `true` | externalTrafficPolicy for Zabbix Java Gateway service. "Local" to preserve sender's IP address. Please note that this might not work on multi-node clusters, depending on your network settings. externalTrafficPolicy: Local |
-| zabbixJavaGateway.service.port | int | `10052` | Port to expose service |
-| zabbixJavaGateway.service.type | string | `"ClusterIP"` | Type of service for Zabbix Java Gateway |
+| zabbixJavaGateway.service.clusterIP | string | `nil` | clusterIP is the IP address of the service and is usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service. |
+| zabbixJavaGateway.service.externalIPs | list | `[]` | externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.  These IPs are not managed by Kubernetes. |
+| zabbixJavaGateway.service.loadBalancerClass | string | `""` | loadBalancerClass is the class of the load balancer implementation this Service belongs to.  If specified, the value of this field must be a label-style identifier, with an optional prefix, e.g. "internal-vip" or  "example.com/internal-vip". Unprefixed names are reserved for end-users. This field can only be set when the Service type is 'LoadBalancer'.  If not set, the default load balancer implementation is used, today this is typically done through the cloud provider integration,  but should apply for any default implementation. If set, it is assumed that a load balancer implementation is watching for Services  with a matching class. Any default load balancer implementation (e.g. cloud providers) should ignore Services that set this field.  This field can only be set when creating or updating a Service to type 'LoadBalancer'. Once set, it can not be changed.  This field will be wiped when a service is updated to a non 'LoadBalancer' type. |
+| zabbixJavaGateway.service.loadBalancerIP | string | `""` | Only applies to Service Type: LoadBalancer. This feature depends on whether the underlying cloud-provider supports specifying  the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature. |
+| zabbixJavaGateway.service.loadBalancerSourceRanges | list | `[]` | If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer  will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature. |
+| zabbixJavaGateway.service.nodePort | int | `31052` | NodePort port to allocate on each node (only if service.type = NodePort or Loadbalancer) |
+| zabbixJavaGateway.service.port | int | `10052` | Port of service in Kubernetes cluster |
+| zabbixJavaGateway.service.sessionAffinity | string | `"None"` | Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity.  Must be ClientIP or None. Defaults to None. More info:  https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies |
+| zabbixJavaGateway.service.type | string | `"ClusterIP"` | Type of service to expose the application. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer.  More details: https://kubernetes.io/docs/concepts/services-networking/service/ |
 | zabbixJavaGateway.startupProbe | object | `{"failureThreshold":5,"initialDelaySeconds":15,"periodSeconds":5,"successThreshold":1,"tcpSocket":{"port":"zabbix-java-gw"},"timeoutSeconds":3}` | The kubelet uses startup probes to know when a container application has started.  Reference: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/ |
 | zabbixJavaGateway.startupProbe.tcpSocket.port | string | `"zabbix-java-gw"` | Port number/alias name of the container |
 | zabbixProxy.ZBX_DEBUGLEVEL | int | `4` |  |
@@ -471,9 +479,15 @@ The following tables lists the configurable parameters of the chart and their de
 | zabbixProxy.resources | object | `{}` | Requests and limits of pod resources. See: [https://kubernetes.io/docs/concepts/configuration/manage-resources-containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers) |
 | zabbixProxy.securityContext | object | `{}` | Security Context configurations. Reference: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
 | zabbixProxy.service.annotations | object | `{}` | Annotations for the zabbix-proxy service |
-| zabbixProxy.service.clusterIP | string | `nil` | Cluster IP for Zabbix Proxy |
-| zabbixProxy.service.port | int | `10051` | Port to expose service |
-| zabbixProxy.service.type | string | `"ClusterIP"` | Type of service for Zabbix Proxy |
+| zabbixProxy.service.clusterIP | string | `nil` | clusterIP is the IP address of the service and is usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service. |
+| zabbixProxy.service.externalIPs | list | `[]` | externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.  These IPs are not managed by Kubernetes. |
+| zabbixProxy.service.loadBalancerClass | string | `""` | loadBalancerClass is the class of the load balancer implementation this Service belongs to.  If specified, the value of this field must be a label-style identifier, with an optional prefix, e.g. "internal-vip" or  "example.com/internal-vip". Unprefixed names are reserved for end-users. This field can only be set when the Service type is 'LoadBalancer'.  If not set, the default load balancer implementation is used, today this is typically done through the cloud provider integration,  but should apply for any default implementation. If set, it is assumed that a load balancer implementation is watching for Services  with a matching class. Any default load balancer implementation (e.g. cloud providers) should ignore Services that set this field.  This field can only be set when creating or updating a Service to type 'LoadBalancer'. Once set, it can not be changed.  This field will be wiped when a service is updated to a non 'LoadBalancer' type. |
+| zabbixProxy.service.loadBalancerIP | string | `""` | Only applies to Service Type: LoadBalancer. This feature depends on whether the underlying cloud-provider supports specifying  the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature. |
+| zabbixProxy.service.loadBalancerSourceRanges | list | `[]` | If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer  will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature. |
+| zabbixProxy.service.nodePort | int | `31053` | NodePort port to allocate on each node (only if service.type = NodePort or Loadbalancer) |
+| zabbixProxy.service.port | int | `10051` | Port of service in Kubernetes cluster |
+| zabbixProxy.service.sessionAffinity | string | `"None"` | Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity.  Must be ClientIP or None. Defaults to None. More info:  https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies |
+| zabbixProxy.service.type | string | `"ClusterIP"` | Type of service to expose the application. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer.  More details: https://kubernetes.io/docs/concepts/services-networking/service/ |
 | zabbixProxy.startupProbe | object | `{}` | The kubelet uses startup probes to know when a container application has started.  Reference: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/ |
 | zabbixProxy.statefulSetAnnotations | object | `{}` | Annotations to add to the statefulset |
 | zabbixProxy.statefulSetLabels | object | `{}` | Labels to add to the statefulset |
@@ -521,12 +535,15 @@ The following tables lists the configurable parameters of the chart and their de
 | zabbixServer.resources | object | `{}` | Requests and limits of pod resources. See: [https://kubernetes.io/docs/concepts/configuration/manage-resources-containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers) |
 | zabbixServer.securityContext | object | `{}` | Security Context configurations. Reference: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
 | zabbixServer.service.annotations | object | `{}` | Annotations for the zabbix-server service |
-| zabbixServer.service.clusterIP | string | `nil` |  |
-| zabbixServer.service.externalIPs | list | `[]` | IPs if use service type LoadBalancer" |
-| zabbixServer.service.loadBalancerIP | string | `""` |  |
-| zabbixServer.service.nodePort | int | `31051` | NodePort of service on each node |
+| zabbixServer.service.clusterIP | string | `nil` | clusterIP is the IP address of the service and is usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service. |
+| zabbixServer.service.externalIPs | list | `[]` | externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.  These IPs are not managed by Kubernetes. |
+| zabbixServer.service.loadBalancerClass | string | `""` | loadBalancerClass is the class of the load balancer implementation this Service belongs to.  If specified, the value of this field must be a label-style identifier, with an optional prefix, e.g. "internal-vip" or  "example.com/internal-vip". Unprefixed names are reserved for end-users. This field can only be set when the Service type is 'LoadBalancer'.  If not set, the default load balancer implementation is used, today this is typically done through the cloud provider integration,  but should apply for any default implementation. If set, it is assumed that a load balancer implementation is watching for Services  with a matching class. Any default load balancer implementation (e.g. cloud providers) should ignore Services that set this field.  This field can only be set when creating or updating a Service to type 'LoadBalancer'. Once set, it can not be changed.  This field will be wiped when a service is updated to a non 'LoadBalancer' type. |
+| zabbixServer.service.loadBalancerIP | string | `""` | Only applies to Service Type: LoadBalancer. This feature depends on whether the underlying cloud-provider supports specifying  the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature. |
+| zabbixServer.service.loadBalancerSourceRanges | list | `[]` | If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer  will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature. |
+| zabbixServer.service.nodePort | int | `31051` | NodePort port to allocate on each node (only if service.type = NodePort or Loadbalancer) |
 | zabbixServer.service.port | int | `10051` | Port of service in Kubernetes cluster |
-| zabbixServer.service.type | string | `"ClusterIP"` | Type of service in Kubernetes cluster |
+| zabbixServer.service.sessionAffinity | string | `"None"` | Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity.  Must be ClientIP or None. Defaults to None. More info:  https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies |
+| zabbixServer.service.type | string | `"ClusterIP"` | Type of service to expose the application. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer.  More details: https://kubernetes.io/docs/concepts/services-networking/service/ |
 | zabbixServer.startupProbe | object | `{}` | The kubelet uses startup probes to know when a container application has started.  Reference: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/ |
 | zabbixWeb.containerAnnotations | object | `{}` | Annotations to add to the containers |
 | zabbixWeb.containerLabels | object | `{}` | Labels to add to the containers |
@@ -561,12 +578,16 @@ The following tables lists the configurable parameters of the chart and their de
 | zabbixWeb.replicaCount | int | `1` | Number of replicas of ``zabbixWeb`` module |
 | zabbixWeb.resources | object | `{}` | Requests and limits of pod resources. See: [https://kubernetes.io/docs/concepts/configuration/manage-resources-containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers) |
 | zabbixWeb.securityContext | object | `{}` | Security Context configurations. Reference: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
-| zabbixWeb.service | object | `{"annotations":{},"clusterIP":null,"externalIPs":[],"loadBalancerIP":"","port":80,"type":"ClusterIP"}` | Certificate containing certificates for SAML configuration samlCertsSecretName: zabbix-web-samlcerts |
+| zabbixWeb.service | object | `{"annotations":{},"clusterIP":null,"externalIPs":[],"loadBalancerClass":"","loadBalancerIP":"","loadBalancerSourceRanges":[],"nodePort":31080,"port":80,"sessionAffinity":"None","type":"ClusterIP"}` | Certificate containing certificates for SAML configuration samlCertsSecretName: zabbix-web-samlcerts |
 | zabbixWeb.service.annotations | object | `{}` | Annotations for the Zabbix Web |
-| zabbixWeb.service.clusterIP | string | `nil` | Cluster IP for Zabbix Web |
-| zabbixWeb.service.externalIPs | list | `[]` | IPs if use service type LoadBalancer" |
-| zabbixWeb.service.port | int | `80` | Port to expose service |
-| zabbixWeb.service.type | string | `"ClusterIP"` | Type of service for Zabbix Web |
+| zabbixWeb.service.clusterIP | string | `nil` | clusterIP is the IP address of the service and is usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service. |
+| zabbixWeb.service.externalIPs | list | `[]` | externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.  These IPs are not managed by Kubernetes. |
+| zabbixWeb.service.loadBalancerClass | string | `""` | loadBalancerClass is the class of the load balancer implementation this Service belongs to.  If specified, the value of this field must be a label-style identifier, with an optional prefix, e.g. "internal-vip" or  "example.com/internal-vip". Unprefixed names are reserved for end-users. This field can only be set when the Service type is 'LoadBalancer'.  If not set, the default load balancer implementation is used, today this is typically done through the cloud provider integration,  but should apply for any default implementation. If set, it is assumed that a load balancer implementation is watching for Services  with a matching class. Any default load balancer implementation (e.g. cloud providers) should ignore Services that set this field.  This field can only be set when creating or updating a Service to type 'LoadBalancer'. Once set, it can not be changed.  This field will be wiped when a service is updated to a non 'LoadBalancer' type. |
+| zabbixWeb.service.loadBalancerIP | string | `""` | Only applies to Service Type: LoadBalancer. This feature depends on whether the underlying cloud-provider supports specifying  the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature. |
+| zabbixWeb.service.loadBalancerSourceRanges | list | `[]` | If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer  will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature. |
+| zabbixWeb.service.nodePort | int | `31080` | NodePort port to allocate on each node (only if service.type = NodePort or Loadbalancer) |
+| zabbixWeb.service.sessionAffinity | string | `"None"` | Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity.  Must be ClientIP or None. Defaults to None. More info:  https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies |
+| zabbixWeb.service.type | string | `"ClusterIP"` | Type of service to expose the application. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer.  More details: https://kubernetes.io/docs/concepts/services-networking/service/ |
 | zabbixWeb.startupProbe | object | `{}` | The kubelet uses startup probes to know when a container application has started.  Reference: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/ |
 | zabbixWebService.containerAnnotations | object | `{}` | Annotations to add to the containers |
 | zabbixWebService.containerLabels | object | `{}` | Labels to add to the containers |
@@ -591,9 +612,9 @@ The following tables lists the configurable parameters of the chart and their de
 | zabbixWebService.securityContext | object | `{}` | Security Context configurations. Reference: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
 | zabbixWebService.service | object | `{"annotations":{},"clusterIP":null,"port":10053,"type":"ClusterIP"}` | Set the IgnoreURLCertErrors configuration setting of Zabbix Web Service ignoreURLCertErrors=1 |
 | zabbixWebService.service.annotations | object | `{}` | Annotations for the Zabbix Web Service |
-| zabbixWebService.service.clusterIP | string | `nil` | Cluster IP for Zabbix Web |
-| zabbixWebService.service.port | int | `10053` | Port to expose service |
-| zabbixWebService.service.type | string | `"ClusterIP"` | Type of service for Zabbix Web |
+| zabbixWebService.service.clusterIP | string | `nil` | clusterIP is the IP address of the service and is usually assigned randomly. If an address is specified manually,  is in-range (as per system configuration), and is not in use, it will be allocated to the service. |
+| zabbixWebService.service.port | int | `10053` | Port of service in Kubernetes cluster |
+| zabbixWebService.service.type | string | `"ClusterIP"` | Type of service to expose the application. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer.  More details: https://kubernetes.io/docs/concepts/services-networking/service/ |
 | zabbixWebService.startupProbe | object | `{}` | The kubelet uses startup probes to know when a container application has started.  Reference: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/ |
 
 ## Configure central database access related settings

--- a/charts/zabbix/README.md.gotmpl
+++ b/charts/zabbix/README.md.gotmpl
@@ -44,7 +44,7 @@ helm search repo zabbix-community/zabbix -l
 Set the helm chart version you want to use. Example:
 
 ```bash
-export ZABBIX_CHART_VERSION='4.4.0'
+export ZABBIX_CHART_VERSION='4.4.1'
 ```
 
 Export default values of ``zabbix`` chart to ``$HOME/zabbix_values.yaml`` file:

--- a/charts/zabbix/artifacthub-pkg.yml
+++ b/charts/zabbix/artifacthub-pkg.yml
@@ -5,13 +5,13 @@
 # https://github.com/kedacore/external-scalers/blob/main/artifacthub/azure-cosmos-db/0.1.0/artifacthub-pkg.yml
 # https://artifacthub.io/packages/keda-scaler/keda-official-external-scalers/external-scaler-azure-cosmos-db?modal=install
 
-version: 4.4.0 # helm chart version
+version: 4.4.1 # helm chart version
 # LTS Zabbix version by default due to stability. See: https://www.zabbix.com/life_cycle_and_release_policy
 appVersion: 6.0.30 # zabbix version
 name: zabbix
 category: monitoring, networking, metrics
 displayName: Zabbix - The Enterprise-Class Open Source Network Monitoring Solution
-createdAt: 2024-05-22T01:57:26Z # Command Linux: date +%Y-%m-%dT%TZ
+createdAt: 2024-05-22T01:57:26Z # Command Linux: 2024-05-26T15:59:35Z
 description: Zabbix is a mature and effortless enterprise-class open source monitoring solution for network monitoring and application monitoring of millions of metrics.
 logoURL: https://assets.zabbix.com/img/logo/zabbix_logo_500x131.png
 license: Apache-2.0
@@ -53,7 +53,7 @@ install: |
   Set the helm chart version you want to use. Example:
 
   ```bash
-  export ZABBIX_CHART_VERSION='4.4.0'
+  export ZABBIX_CHART_VERSION='4.4.1'
   ```
 
   Export default values of ``zabbix`` chart to ``$HOME/zabbix_values.yaml`` file:

--- a/charts/zabbix/docs/example/kind/values.yaml
+++ b/charts/zabbix/docs/example/kind/values.yaml
@@ -78,6 +78,7 @@ zabbixProxy:
   service:
     type: NodePort
     port: 10051
+    nodePort: 31053
   extraEnv:
     - name: "ZBX_EXAMPLE_MY_ENV_4"
       value: "true"

--- a/charts/zabbix/templates/service.yaml
+++ b/charts/zabbix/templates/service.yaml
@@ -18,30 +18,39 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.zabbixServer.service.type }}
-  {{- if .Values.zabbixServer.service.externalTrafficPolicy }}
+  {{- if and .Values.zabbixServer.service.externalTrafficPolicy (or (eq .Values.zabbixServer.service.type "NodePort") (eq .Values.zabbixServer.service.type "LoadBalancer" )) }}
   externalTrafficPolicy: {{ .Values.zabbixServer.service.externalTrafficPolicy }}
   {{- end }}
-  {{- if .Values.zabbixServer.service.externalIPs }}
+  {{- if and .Values.zabbixServer.service.externalIPs (eq .Values.zabbixServer.service.type "LoadBalancer") }}
   externalIPs: {{ .Values.zabbixServer.service.externalIPs | toYaml | nindent 6 }}
   {{- end }}
-  {{- if .Values.zabbixServer.service.loadBalancerIP }}
+  {{- if and .Values.zabbixServer.service.loadBalancerIP (eq .Values.zabbixServer.service.type "LoadBalancer") }}
   loadBalancerIP: {{ .Values.zabbixServer.service.loadBalancerIP }}
   {{- end }}
-  {{- if .Values.zabbixServer.service.clusterIP }}
+  {{- if and .Values.zabbixServer.service.clusterIP (eq .Values.zabbixServer.service.type "ClusterIP") }}
   clusterIP: {{ .Values.zabbixServer.service.clusterIP }}
+  {{- end }}
+  {{- if .Values.zabbixServer.service.sessionAffinity }}
+  sessionAffinity: {{ .Values.zabbixServer.service.sessionAffinity }}
+  {{- end }}
+  {{- if and (eq .Values.zabbixServer.service.type "LoadBalancer") (not (empty .Values.zabbixServer.service.loadBalancerSourceRanges)) }}
+  loadBalancerSourceRanges: {{- toYaml .Values.zabbixServer.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
+  {{- if and (eq .Values.zabbixServer.service.type "LoadBalancer") .Values.zabbixServer.service.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.zabbixServer.service.loadBalancerClass }}
   {{- end }}
   ports:
     - port: {{ .Values.zabbixServer.service.port }}
-      targetPort: 10051
       name: zabbix-server
+      targetPort: 10051
       protocol: TCP
-      {{- if ( and (eq .Values.zabbixServer.service.type "NodePort" ) (not (empty .Values.zabbixServer.service.nodePort)) ) }}
+      {{- if and (or (eq .Values.zabbixServer.service.type "NodePort") (eq .Values.zabbixServer.service.type "LoadBalancer" )) (not (empty .Values.zabbixServer.service.nodePort)) }}
       nodePort: {{ .Values.zabbixServer.service.nodePort }}
       {{- end }}
     - port: 10052
+      name: zabbix-jmx
       targetPort: 10052
       protocol: TCP
-      name: zabbix-jmx
   selector:
     app: {{ template "zabbix.fullname" . }}-zabbix-server
 {{- end }}
@@ -67,26 +76,35 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.zabbixAgent.service.type }}
-  {{- if .Values.zabbixAgent.service.externalTrafficPolicy }}
+  {{- if and .Values.zabbixAgent.service.externalTrafficPolicy (or (eq .Values.zabbixAgent.service.type "NodePort") (eq .Values.zabbixAgent.service.type "LoadBalancer" )) }}
   externalTrafficPolicy: {{ .Values.zabbixAgent.service.externalTrafficPolicy }}
   {{- end }}
-  {{- if .Values.zabbixAgent.service.externalIPs }}
+  {{- if and .Values.zabbixAgent.service.externalIPs (eq .Values.zabbixAgent.service.type "LoadBalancer") }}
   externalIPs: {{ .Values.zabbixAgent.service.externalIPs | toYaml | nindent 6 }}
   {{- end }}
-  {{- if .Values.zabbixAgent.service.loadBalancerIP }}
+  {{- if and .Values.zabbixAgent.service.loadBalancerIP (eq .Values.zabbixAgent.service.type "LoadBalancer") }}
   loadBalancerIP: {{ .Values.zabbixAgent.service.loadBalancerIP }}
   {{- end }}
-  {{- if .Values.zabbixAgent.service.clusterIP }}
+  {{- if and .Values.zabbixAgent.service.clusterIP (eq .Values.zabbixAgent.service.type "ClusterIP") }}
   clusterIP: {{ .Values.zabbixAgent.service.clusterIP }}
+  {{- end }}
+  {{- if .Values.zabbixAgent.service.sessionAffinity }}
+  sessionAffinity: {{ .Values.zabbixAgent.service.sessionAffinity }}
+  {{- end }}
+  {{- if and (eq .Values.zabbixAgent.service.type "LoadBalancer") (not (empty .Values.zabbixAgent.service.loadBalancerSourceRanges)) }}
+  loadBalancerSourceRanges: {{- toYaml .Values.zabbixAgent.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
+  {{- if and (eq .Values.zabbixAgent.service.type "LoadBalancer") .Values.zabbixAgent.service.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.zabbixAgent.service.loadBalancerClass }}
   {{- end }}
   ports:
     - port: {{ .Values.zabbixAgent.service.port }}
+      name: zabbix-agent
       targetPort: 10050
-      {{- if ( and (eq .Values.zabbixAgent.service.type "NodePort" ) (not (empty .Values.zabbixAgent.service.nodePort)) ) }}
+      protocol: TCP
+      {{- if and (or (eq .Values.zabbixAgent.service.type "NodePort") (eq .Values.zabbixAgent.service.type "LoadBalancer" )) (not (empty .Values.zabbixAgent.service.nodePort)) }}
       nodePort: {{ .Values.zabbixAgent.service.nodePort }}
       {{- end }}
-      protocol: TCP
-      name: zabbix-agent
   selector:
     app: {{ template "zabbix.fullname" . }}-zabbix-agent
 {{- end }}
@@ -112,24 +130,33 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.zabbixWeb.service.type }}
-  {{- if .Values.zabbixWeb.service.externalTrafficPolicy }}
+  {{- if and .Values.zabbixWeb.service.externalTrafficPolicy (or (eq .Values.zabbixWeb.service.type "NodePort") (eq .Values.zabbixWeb.service.type "LoadBalancer" )) }}
   externalTrafficPolicy: {{ .Values.zabbixWeb.service.externalTrafficPolicy }}
   {{- end }}
-  {{- if .Values.zabbixWeb.service.externalIPs }}
+  {{- if and .Values.zabbixWeb.service.externalIPs (eq .Values.zabbixWeb.service.type "LoadBalancer") }}
   externalIPs: {{ .Values.zabbixWeb.service.externalIPs | toYaml | nindent 6 }}
   {{- end }}
-  {{- if .Values.zabbixWeb.service.loadBalancerIP }}
+  {{- if and .Values.zabbixWeb.service.loadBalancerIP (eq .Values.zabbixWeb.service.type "LoadBalancer") }}
   loadBalancerIP: {{ .Values.zabbixWeb.service.loadBalancerIP }}
   {{- end }}
-  {{- if .Values.zabbixWeb.service.clusterIP }}
+  {{- if and .Values.zabbixWeb.service.clusterIP (eq .Values.zabbixWeb.service.type "ClusterIP") }}
   clusterIP: {{ .Values.zabbixWeb.service.clusterIP }}
+  {{- end }}
+  {{- if .Values.zabbixWeb.service.sessionAffinity }}
+  sessionAffinity: {{ .Values.zabbixWeb.service.sessionAffinity }}
+  {{- end }}
+  {{- if and (eq .Values.zabbixWeb.service.type "LoadBalancer") (not (empty .Values.zabbixWeb.service.loadBalancerSourceRanges)) }}
+  loadBalancerSourceRanges: {{- toYaml .Values.zabbixWeb.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
+  {{- if and (eq .Values.zabbixWeb.service.type "LoadBalancer") .Values.zabbixWeb.service.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.zabbixWeb.service.loadBalancerClass }}
   {{- end }}
   ports:
     - port: {{ .Values.zabbixWeb.service.port }}
+      name: zabbix-web
       targetPort: 8080
       protocol: TCP
-      name: zabbix-web
-      {{- if ( and (eq .Values.zabbixWeb.service.type "NodePort" ) (not (empty .Values.zabbixWeb.service.nodePort)) ) }}
+      {{- if and (or (eq .Values.zabbixWeb.service.type "NodePort") (eq .Values.zabbixWeb.service.type "LoadBalancer" )) (not (empty .Values.zabbixWeb.service.nodePort)) }}
       nodePort: {{ .Values.zabbixWeb.service.nodePort }}
       {{- end }}
   selector:
@@ -157,14 +184,14 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.zabbixWebService.service.type }}
-  {{- if .Values.zabbixWebService.service.clusterIP }}
+  {{- if and .Values.zabbixWebService.service.clusterIP (eq .Values.zabbixWebService.service.type "ClusterIP") }}
   clusterIP: {{ .Values.zabbixWebService.service.clusterIP }}
   {{- end }}
   ports:
     - port: {{ .Values.zabbixWebService.service.port }}
+      name: webservice
       targetPort: 10053
       protocol: TCP
-      name: webservice
   selector:
     app: {{ template "zabbix.fullname" . }}-zabbix-webservice
   {{- end }}
@@ -190,14 +217,35 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.zabbixProxy.service.type }}
-  {{- if .Values.zabbixProxy.service.clusterIP }}
+  {{- if and .Values.zabbixProxy.service.externalTrafficPolicy (or (eq .Values.zabbixProxy.service.type "NodePort") (eq .Values.zabbixProxy.service.type "LoadBalancer" )) }}
+  externalTrafficPolicy: {{ .Values.zabbixProxy.service.externalTrafficPolicy }}
+  {{- end }}
+  {{- if and .Values.zabbixProxy.service.externalIPs (eq .Values.zabbixProxy.service.type "LoadBalancer") }}
+  externalIPs: {{ .Values.zabbixProxy.service.externalIPs | toYaml | nindent 6 }}
+  {{- end }}
+  {{- if and .Values.zabbixProxy.service.loadBalancerIP (eq .Values.zabbixProxy.service.type "LoadBalancer") }}
+  loadBalancerIP: {{ .Values.zabbixProxy.service.loadBalancerIP }}
+  {{- end }}
+  {{- if and .Values.zabbixProxy.service.clusterIP (eq .Values.zabbixProxy.service.type "ClusterIP") }}
   clusterIP: {{ .Values.zabbixProxy.service.clusterIP }}
+  {{- end }}
+  {{- if .Values.zabbixProxy.service.sessionAffinity }}
+  sessionAffinity: {{ .Values.zabbixProxy.service.sessionAffinity }}
+  {{- end }}
+  {{- if and (eq .Values.zabbixProxy.service.type "LoadBalancer") (not (empty .Values.zabbixProxy.service.loadBalancerSourceRanges)) }}
+  loadBalancerSourceRanges: {{- toYaml .Values.zabbixProxy.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
+  {{- if and (eq .Values.zabbixProxy.service.type "LoadBalancer") .Values.zabbixProxy.service.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.zabbixProxy.service.loadBalancerClass }}
   {{- end }}
   ports:
     - port: {{ .Values.zabbixProxy.service.port }}
+      name: zabbix-proxy
       targetPort: 10051
       protocol: TCP
-      name: zabbix-proxy
+      {{- if and (or (eq .Values.zabbixProxy.service.type "NodePort") (eq .Values.zabbixProxy.service.type "LoadBalancer" )) (not (empty .Values.zabbixProxy.service.nodePort)) }}
+      nodePort: {{ .Values.zabbixProxy.service.nodePort }}
+      {{- end }}
   selector:
     app: {{ template "zabbix.fullname" . }}-zabbix-proxy
 {{- end }}
@@ -222,14 +270,14 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.postgresql.service.type }}
-  {{- if .Values.postgresql.service.clusterIP }}
+  {{- if and .Values.postgresql.service.clusterIP (eq .Values.postgresql.service.type "ClusterIP") }}
   clusterIP: {{ .Values.postgresql.service.clusterIP }}
   {{- end }}
   ports:
     - port: {{ .Values.postgresql.service.port }}
+      name: db
       targetPort: 5432
       protocol: TCP
-      name: db
   selector:
     app: {{ template "zabbix.fullname" . }}-postgresql
 {{- end }}
@@ -254,17 +302,35 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.zabbixJavaGateway.service.type }}
-  {{- if .Values.zabbixJavaGateway.service.clusterIP }}
+  {{- if and .Values.zabbixJavaGateway.service.externalTrafficPolicy (or (eq .Values.zabbixJavaGateway.service.type "NodePort") (eq .Values.zabbixJavaGateway.service.type "LoadBalancer" )) }}
+  externalTrafficPolicy: {{ .Values.zabbixJavaGateway.service.externalTrafficPolicy }}
+  {{- end }}
+  {{- if and .Values.zabbixJavaGateway.service.externalIPs (eq .Values.zabbixJavaGateway.service.type "LoadBalancer") }}
+  externalIPs: {{ .Values.zabbixJavaGateway.service.externalIPs | toYaml | nindent 6 }}
+  {{- end }}
+  {{- if and .Values.zabbixJavaGateway.service.loadBalancerIP (eq .Values.zabbixJavaGateway.service.type "LoadBalancer") }}
+  loadBalancerIP: {{ .Values.zabbixJavaGateway.service.loadBalancerIP }}
+  {{- end }}
+  {{- if and .Values.zabbixJavaGateway.service.clusterIP (eq .Values.zabbixJavaGateway.service.type "ClusterIP") }}
   clusterIP: {{ .Values.zabbixJavaGateway.service.clusterIP }}
+  {{- end }}
+  {{- if .Values.zabbixJavaGateway.service.sessionAffinity }}
+  sessionAffinity: {{ .Values.zabbixJavaGateway.service.sessionAffinity }}
+  {{- end }}
+  {{- if and (eq .Values.zabbixJavaGateway.service.type "LoadBalancer") (not (empty .Values.zabbixJavaGateway.service.loadBalancerSourceRanges)) }}
+  loadBalancerSourceRanges: {{- toYaml .Values.zabbixJavaGateway.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
+  {{- if and (eq .Values.zabbixJavaGateway.service.type "LoadBalancer") .Values.zabbixJavaGateway.service.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.zabbixJavaGateway.service.loadBalancerClass }}
   {{- end }}
   ports:
     - port: {{ .Values.zabbixJavaGateway.service.port }}
+      name: zabbix-java-gw
       targetPort: 10052
+      protocol: TCP
       {{- if ( and (eq .Values.zabbixJavaGateway.service.type "NodePort" ) (not (empty .Values.zabbixJavaGateway.service.nodePort)) ) }}
       nodePort: {{ .Values.zabbixJavaGateway.service.nodePort }}
       {{- end }}
-      protocol: TCP
-      name: zabbix-java-gw
   selector:
     app: {{ template "zabbix.fullname" . }}-{{ .Values.zabbixJavaGateway.ZBX_JAVAGATEWAY }}
 {{- end }}

--- a/charts/zabbix/values.yaml
+++ b/charts/zabbix/values.yaml
@@ -138,18 +138,41 @@ zabbixServer:
     # -- Security Context configurations. Reference: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
     securityContext: {}
   service:
-    # -- Type of service in Kubernetes cluster
+    # -- Type of service to expose the application. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. 
+    #More details: https://kubernetes.io/docs/concepts/services-networking/service/
     type: ClusterIP
-    # -- Cluster IP for Zabbix Server
-    # -- externalTrafficPolicy for Zabbix Server. "Local" to preserve sender's IP address. Please note that this might not work on multi-node clusters, depending on your network settings.
-    #externalTrafficPolicy: Local
-    # -- IPs if use service type LoadBalancer"
-    externalIPs: []
-    loadBalancerIP: ""
+    # -- clusterIP is the IP address of the service and is usually assigned randomly. 
+    #If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service.
     clusterIP:
+    # -- externalTrafficPolicy describes how nodes distribute service traffic they receive on one of the Service's "externally-facing" addresses 
+    #(NodePorts, ExternalIPs, and LoadBalancer IPs). "Local" to preserve sender's IP address. Please note that this might not work on multi-node clusters, 
+    #depending on your network settings.
+    #externalTrafficPolicy: Local
+    # -- externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service. 
+    #These IPs are not managed by Kubernetes.
+    externalIPs: []
+    # -- Only applies to Service Type: LoadBalancer. This feature depends on whether the underlying cloud-provider supports specifying 
+    #the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature.
+    loadBalancerIP: ""
+    # -- If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer 
+    #will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature.
+    loadBalancerSourceRanges: []
+    # -- loadBalancerClass is the class of the load balancer implementation this Service belongs to. 
+    #If specified, the value of this field must be a label-style identifier, with an optional prefix, e.g. "internal-vip" or 
+    #"example.com/internal-vip". Unprefixed names are reserved for end-users. This field can only be set when the Service type is 'LoadBalancer'. 
+    #If not set, the default load balancer implementation is used, today this is typically done through the cloud provider integration, 
+    #but should apply for any default implementation. If set, it is assumed that a load balancer implementation is watching for Services 
+    #with a matching class. Any default load balancer implementation (e.g. cloud providers) should ignore Services that set this field. 
+    #This field can only be set when creating or updating a Service to type 'LoadBalancer'. Once set, it can not be changed. 
+    #This field will be wiped when a service is updated to a non 'LoadBalancer' type.
+    loadBalancerClass: ""
+    # -- Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. 
+    #Must be ClientIP or None. Defaults to None. More info: 
+    #https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+    sessionAffinity: None
     # -- Port of service in Kubernetes cluster
     port: 10051
-    # -- NodePort of service on each node
+    # -- NodePort port to allocate on each node (only if service.type = NodePort or Loadbalancer)
     nodePort: 31051
     # -- Annotations for the zabbix-server service
     annotations: {}
@@ -214,9 +237,11 @@ postgresql:
     # -- Storage PVC storageclass to use
     #storageClass: my-storage-class
   service:
-    # -- Type of service in Kubernetes cluster
+    # -- Type of service to expose the application. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer.
+    # More details: https://kubernetes.io/docs/concepts/services-networking/service/
     type: ClusterIP
-    # -- Cluster IP for Zabbix Server
+    # -- clusterIP is the IP address of the service and is usually assigned randomly. If an address is specified manually, 
+    #is in-range (as per system configuration), and is not in use, it will be allocated to the service.
     clusterIP:
     # -- Port of service in Kubernetes cluster
     port: 5432
@@ -291,12 +316,42 @@ zabbixProxy:
   # -- Cache size
   ZBX_VMWARECACHESIZE: 128M
   service:
-    # -- Type of service for Zabbix Proxy
+    # -- Type of service to expose the application. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. 
+    #More details: https://kubernetes.io/docs/concepts/services-networking/service/
     type: ClusterIP
-    # -- Cluster IP for Zabbix Proxy
+    # -- clusterIP is the IP address of the service and is usually assigned randomly. 
+    #If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service.
     clusterIP:
-    # -- Port to expose service
+    # -- externalTrafficPolicy describes how nodes distribute service traffic they receive on one of the Service's "externally-facing" addresses 
+    #(NodePorts, ExternalIPs, and LoadBalancer IPs). "Local" to preserve sender's IP address. Please note that this might not work on multi-node clusters, 
+    #depending on your network settings.
+    #externalTrafficPolicy: Local
+    # -- externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service. 
+    #These IPs are not managed by Kubernetes.
+    externalIPs: []
+    # -- Only applies to Service Type: LoadBalancer. This feature depends on whether the underlying cloud-provider supports specifying 
+    #the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature.
+    loadBalancerIP: ""
+    # -- If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer 
+    #will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature.
+    loadBalancerSourceRanges: []
+    # -- loadBalancerClass is the class of the load balancer implementation this Service belongs to. 
+    #If specified, the value of this field must be a label-style identifier, with an optional prefix, e.g. "internal-vip" or 
+    #"example.com/internal-vip". Unprefixed names are reserved for end-users. This field can only be set when the Service type is 'LoadBalancer'. 
+    #If not set, the default load balancer implementation is used, today this is typically done through the cloud provider integration, 
+    #but should apply for any default implementation. If set, it is assumed that a load balancer implementation is watching for Services 
+    #with a matching class. Any default load balancer implementation (e.g. cloud providers) should ignore Services that set this field. 
+    #This field can only be set when creating or updating a Service to type 'LoadBalancer'. Once set, it can not be changed. 
+    #This field will be wiped when a service is updated to a non 'LoadBalancer' type.
+    loadBalancerClass: ""
+    # -- Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. 
+    #Must be ClientIP or None. Defaults to None. More info: 
+    #https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+    sessionAffinity: None
+    # -- Port of service in Kubernetes cluster
     port: 10051
+    # -- NodePort port to allocate on each node (only if service.type = NodePort or Loadbalancer)
+    nodePort: 31053
     # -- Annotations for the zabbix-proxy service
     annotations: {}
     # metallb.universe.tf/address-pool: production-public-ips
@@ -369,22 +424,42 @@ zabbixAgent:
   # -- The variable is used to specify timeout for processing checks. By default, value is 4.
   ZBX_TIMEOUT: 4
   service:
-    # -- Type of service for Zabbix Agent
+    # -- Type of service to expose the application. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. 
+    #More details: https://kubernetes.io/docs/concepts/services-networking/service/
     type: ClusterIP
-    # -- externalTrafficPolicy for Zabbix Agent. "Local" to preserve sender's IP address. Please note that this might not work on multi-node clusters, depending on your network settings.
-    #externalTrafficPolicy: Local
-    # -- IPs if use service type LoadBalancer"
-    externalIPs: []
-    loadBalancerIP: ""
-    # -- Cluster IP for Zabbix Agent
+    # -- clusterIP is the IP address of the service and is usually assigned randomly. 
+    #If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service.
     clusterIP:
-    # -- Port to expose service
-    port: 10050
-    # -- externalTrafficPolicy for Zabbix Agent service. "Local" to preserve sender's IP address. Please note that this might not work on multi-node clusters, depending on your network settings.
+    # -- externalTrafficPolicy describes how nodes distribute service traffic they receive on one of the Service's "externally-facing" addresses 
+    #(NodePorts, ExternalIPs, and LoadBalancer IPs). "Local" to preserve sender's IP address. Please note that this might not work on multi-node clusters, 
+    #depending on your network settings.
     #externalTrafficPolicy: Local
-    listenOnAllInterfaces: true
-    # -- NodePort port to allocate (only if service.type = NodePort)
-    #nodePort: 31050
+    # -- externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service. 
+    #These IPs are not managed by Kubernetes.
+    externalIPs: []
+    # -- Only applies to Service Type: LoadBalancer. This feature depends on whether the underlying cloud-provider supports specifying 
+    #the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature.
+    loadBalancerIP: ""
+    # -- If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer 
+    #will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature.
+    loadBalancerSourceRanges: []
+    # -- loadBalancerClass is the class of the load balancer implementation this Service belongs to. 
+    #If specified, the value of this field must be a label-style identifier, with an optional prefix, e.g. "internal-vip" or 
+    #"example.com/internal-vip". Unprefixed names are reserved for end-users. This field can only be set when the Service type is 'LoadBalancer'. 
+    #If not set, the default load balancer implementation is used, today this is typically done through the cloud provider integration, 
+    #but should apply for any default implementation. If set, it is assumed that a load balancer implementation is watching for Services 
+    #with a matching class. Any default load balancer implementation (e.g. cloud providers) should ignore Services that set this field. 
+    #This field can only be set when creating or updating a Service to type 'LoadBalancer'. Once set, it can not be changed. 
+    #This field will be wiped when a service is updated to a non 'LoadBalancer' type.
+    loadBalancerClass: ""
+    # -- Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. 
+    #Must be ClientIP or None. Defaults to None. More info: 
+    #https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+    sessionAffinity: None
+    # -- Port of service in Kubernetes cluster
+    port: 10050
+    # -- NodePort port to allocate on each node (only if service.type = NodePort or Loadbalancer)
+    nodePort: 31050
     # -- Annotations for the zabbix-agent service
     annotations: {}
     # metallb.universe.tf/address-pool: production-public-ips
@@ -458,19 +533,41 @@ zabbixWeb:
   # -- Certificate containing certificates for SAML configuration
   #samlCertsSecretName: zabbix-web-samlcerts
   service:
-    # -- Type of service for Zabbix Web
+    # -- Type of service to expose the application. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. 
+    #More details: https://kubernetes.io/docs/concepts/services-networking/service/
     type: ClusterIP
-    # -- externalTrafficPolicy for Zabbix Web. "Local" to preserve sender's IP address. Please note that this might not work on multi-node clusters, depending on your network settings.
-    #externalTrafficPolicy: Local
-    # -- IPs if use service type LoadBalancer"
-    externalIPs: []
-    loadBalancerIP: ""
-    # -- Cluster IP for Zabbix Web
+    # -- clusterIP is the IP address of the service and is usually assigned randomly. 
+    #If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service.
     clusterIP:
-    # -- Port to expose service
+    # -- externalTrafficPolicy describes how nodes distribute service traffic they receive on one of the Service's "externally-facing" addresses 
+    #(NodePorts, ExternalIPs, and LoadBalancer IPs). "Local" to preserve sender's IP address. Please note that this might not work on multi-node clusters, 
+    #depending on your network settings.
+    #externalTrafficPolicy: Local
+    # -- externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service. 
+    #These IPs are not managed by Kubernetes.
+    externalIPs: []
+    # -- Only applies to Service Type: LoadBalancer. This feature depends on whether the underlying cloud-provider supports specifying 
+    #the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature.
+    loadBalancerIP: ""
+    # -- If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer 
+    #will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature.
+    loadBalancerSourceRanges: []
+    # -- loadBalancerClass is the class of the load balancer implementation this Service belongs to. 
+    #If specified, the value of this field must be a label-style identifier, with an optional prefix, e.g. "internal-vip" or 
+    #"example.com/internal-vip". Unprefixed names are reserved for end-users. This field can only be set when the Service type is 'LoadBalancer'. 
+    #If not set, the default load balancer implementation is used, today this is typically done through the cloud provider integration, 
+    #but should apply for any default implementation. If set, it is assumed that a load balancer implementation is watching for Services 
+    #with a matching class. Any default load balancer implementation (e.g. cloud providers) should ignore Services that set this field. 
+    #This field can only be set when creating or updating a Service to type 'LoadBalancer'. Once set, it can not be changed. 
+    #This field will be wiped when a service is updated to a non 'LoadBalancer' type.
+    loadBalancerClass: ""
+    # -- Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. 
+    #Must be ClientIP or None. Defaults to None. More info: 
+    #https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+    sessionAffinity: None    # -- Port of service in Kubernetes cluster
     port: 80
-    # -- NodePort port to allocate (only if service.type = NodePort)
-    #nodePort: 31080
+    # -- NodePort port to allocate on each node (only if service.type = NodePort or Loadbalancer)
+    nodePort: 31080
     # -- Annotations for the Zabbix Web
     annotations: {}
     # metallb.universe.tf/address-pool: production-public-ips
@@ -547,11 +644,13 @@ zabbixWebService:
   # -- Set the IgnoreURLCertErrors configuration setting of Zabbix Web Service
   #ignoreURLCertErrors=1
   service:
-    # -- Type of service for Zabbix Web
+    # -- Type of service to expose the application. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. 
+    #More details: https://kubernetes.io/docs/concepts/services-networking/service/
     type: ClusterIP
-    # -- Cluster IP for Zabbix Web
+    # -- clusterIP is the IP address of the service and is usually assigned randomly. If an address is specified manually, 
+    #is in-range (as per system configuration), and is not in use, it will be allocated to the service.
     clusterIP:
-    # -- Port to expose service
+    # -- Port of service in Kubernetes cluster
     port: 10053
     # -- Annotations for the Zabbix Web Service
     annotations: {}
@@ -616,17 +715,42 @@ zabbixJavaGateway:
   ZBX_JAVAGATEWAY: zabbix-java-gateway
   # Java Gateway Service Port
   service:
-    # -- Type of service for Zabbix Java Gateway
+    # -- Type of service to expose the application. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. 
+    #More details: https://kubernetes.io/docs/concepts/services-networking/service/
     type: ClusterIP
-    # -- Cluster IP for Zabbix Java Gateway
+    # -- clusterIP is the IP address of the service and is usually assigned randomly. 
+    #If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service.
     clusterIP:
-    # -- Port to expose service
-    port: 10052
-    # -- externalTrafficPolicy for Zabbix Java Gateway service. "Local" to preserve sender's IP address. Please note that this might not work on multi-node clusters, depending on your network settings.
+    # -- externalTrafficPolicy describes how nodes distribute service traffic they receive on one of the Service's "externally-facing" addresses 
+    #(NodePorts, ExternalIPs, and LoadBalancer IPs). "Local" to preserve sender's IP address. Please note that this might not work on multi-node clusters, 
+    #depending on your network settings.
     #externalTrafficPolicy: Local
-    listenOnAllInterfaces: true
-    # -- NodePort port to allocate (only if service.type = NodePort)
-    #nodePort: 31052
+    # -- externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service. 
+    #These IPs are not managed by Kubernetes.
+    externalIPs: []
+    # -- Only applies to Service Type: LoadBalancer. This feature depends on whether the underlying cloud-provider supports specifying 
+    #the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature.
+    loadBalancerIP: ""
+    # -- If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer 
+    #will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature.
+    loadBalancerSourceRanges: []
+    # -- loadBalancerClass is the class of the load balancer implementation this Service belongs to. 
+    #If specified, the value of this field must be a label-style identifier, with an optional prefix, e.g. "internal-vip" or 
+    #"example.com/internal-vip". Unprefixed names are reserved for end-users. This field can only be set when the Service type is 'LoadBalancer'. 
+    #If not set, the default load balancer implementation is used, today this is typically done through the cloud provider integration, 
+    #but should apply for any default implementation. If set, it is assumed that a load balancer implementation is watching for Services 
+    #with a matching class. Any default load balancer implementation (e.g. cloud providers) should ignore Services that set this field. 
+    #This field can only be set when creating or updating a Service to type 'LoadBalancer'. Once set, it can not be changed. 
+    #This field will be wiped when a service is updated to a non 'LoadBalancer' type.
+    loadBalancerClass: ""
+    # -- Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. 
+    #Must be ClientIP or None. Defaults to None. More info: 
+    #https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+    sessionAffinity: None
+    # -- Port of service in Kubernetes cluster
+    port: 10052
+    # -- NodePort port to allocate on each node (only if service.type = NodePort or Loadbalancer)
+    nodePort: 31052
     # -- Annotations for the zabbix-java-gateway service
     annotations: {}
     # metallb.universe.tf/address-pool: production-public-ips

--- a/charts/zabbix/values.yaml
+++ b/charts/zabbix/values.yaml
@@ -713,7 +713,6 @@ zabbixJavaGateway:
   # ZABBIX_OPTIONS: 
   # Java Gateway Service Name
   ZBX_JAVAGATEWAY: zabbix-java-gateway
-  # Java Gateway Service Port
   service:
     # -- Type of service to expose the application. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. 
     #More details: https://kubernetes.io/docs/concepts/services-networking/service/


### PR DESCRIPTION
#### What this PR does / why we need it:

- Added new values
- Updated documentation
- Refactory in all services templates of Zabbix Components
- Bump chart version

New values:

```yaml
zabbixServer:
  service:
    # -- Type of service to expose the application. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. 
    #More details: https://kubernetes.io/docs/concepts/services-networking/service/
    type: ClusterIP
    # -- clusterIP is the IP address of the service and is usually assigned randomly. 
    #If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service.
    clusterIP:
    # -- externalTrafficPolicy describes how nodes distribute service traffic they receive on one of the Service's "externally-facing" addresses 
    #(NodePorts, ExternalIPs, and LoadBalancer IPs). "Local" to preserve sender's IP address. Please note that this might not work on multi-node clusters, 
    #depending on your network settings.
    #externalTrafficPolicy: Local
    # -- externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service. 
    #These IPs are not managed by Kubernetes.
    externalIPs: []
    # -- Only applies to Service Type: LoadBalancer. This feature depends on whether the underlying cloud-provider supports specifying 
    #the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature.
    loadBalancerIP: ""
    # -- If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer 
    #will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature.
    loadBalancerSourceRanges: []
    # -- loadBalancerClass is the class of the load balancer implementation this Service belongs to. 
    #If specified, the value of this field must be a label-style identifier, with an optional prefix, e.g. "internal-vip" or 
    #"example.com/internal-vip". Unprefixed names are reserved for end-users. This field can only be set when the Service type is 'LoadBalancer'. 
    #If not set, the default load balancer implementation is used, today this is typically done through the cloud provider integration, 
    #but should apply for any default implementation. If set, it is assumed that a load balancer implementation is watching for Services 
    #with a matching class. Any default load balancer implementation (e.g. cloud providers) should ignore Services that set this field. 
    #This field can only be set when creating or updating a Service to type 'LoadBalancer'. Once set, it can not be changed. 
    #This field will be wiped when a service is updated to a non 'LoadBalancer' type.
    loadBalancerClass: ""
    # -- Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. 
    #Must be ClientIP or None. Defaults to None. More info: 
    #https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
    sessionAffinity: None
    # -- Port of service in Kubernetes cluster
    port: 10051
    # -- NodePort port to allocate on each node (only if service.type = NodePort or Loadbalancer)
    nodePort: 31051
    # -- Annotations for the zabbix-server service

postgresql:
  service:
    # -- Type of service to expose the application. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer.
    # More details: https://kubernetes.io/docs/concepts/services-networking/service/
    type: ClusterIP
    # -- clusterIP is the IP address of the service and is usually assigned randomly. If an address is specified manually, 
    #is in-range (as per system configuration), and is not in use, it will be allocated to the service.
    clusterIP:
    # -- Port of service in Kubernetes cluster
    port: 5432

zabbixProxy:
  service:
    # -- Type of service to expose the application. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. 
    #More details: https://kubernetes.io/docs/concepts/services-networking/service/
    type: ClusterIP
    # -- clusterIP is the IP address of the service and is usually assigned randomly. 
    #If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service.
    clusterIP:
    # -- externalTrafficPolicy describes how nodes distribute service traffic they receive on one of the Service's "externally-facing" addresses 
    #(NodePorts, ExternalIPs, and LoadBalancer IPs). "Local" to preserve sender's IP address. Please note that this might not work on multi-node clusters, 
    #depending on your network settings.
    #externalTrafficPolicy: Local
    # -- externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service. 
    #These IPs are not managed by Kubernetes.
    externalIPs: []
    # -- Only applies to Service Type: LoadBalancer. This feature depends on whether the underlying cloud-provider supports specifying 
    #the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature.
    loadBalancerIP: ""
    # -- If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer 
    #will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature.
    loadBalancerSourceRanges: []
    # -- loadBalancerClass is the class of the load balancer implementation this Service belongs to. 
    #If specified, the value of this field must be a label-style identifier, with an optional prefix, e.g. "internal-vip" or 
    #"example.com/internal-vip". Unprefixed names are reserved for end-users. This field can only be set when the Service type is 'LoadBalancer'. 
    #If not set, the default load balancer implementation is used, today this is typically done through the cloud provider integration, 
    #but should apply for any default implementation. If set, it is assumed that a load balancer implementation is watching for Services 
    #with a matching class. Any default load balancer implementation (e.g. cloud providers) should ignore Services that set this field. 
    #This field can only be set when creating or updating a Service to type 'LoadBalancer'. Once set, it can not be changed. 
    #This field will be wiped when a service is updated to a non 'LoadBalancer' type.
    loadBalancerClass: ""
    # -- Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. 
    #Must be ClientIP or None. Defaults to None. More info: 
    #https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
    sessionAffinity: None
    # -- Port of service in Kubernetes cluster
    port: 10051
    # -- NodePort port to allocate on each node (only if service.type = NodePort or Loadbalancer)
    nodePort: 31053

zabbixAgent:
  service:
    # -- Type of service to expose the application. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. 
    #More details: https://kubernetes.io/docs/concepts/services-networking/service/
    type: ClusterIP
    # -- clusterIP is the IP address of the service and is usually assigned randomly. 
    #If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service.
    clusterIP:
    # -- externalTrafficPolicy describes how nodes distribute service traffic they receive on one of the Service's "externally-facing" addresses 
    #(NodePorts, ExternalIPs, and LoadBalancer IPs). "Local" to preserve sender's IP address. Please note that this might not work on multi-node clusters, 
    #depending on your network settings.
    #externalTrafficPolicy: Local
    # -- externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service. 
    #These IPs are not managed by Kubernetes.
    externalIPs: []
    # -- Only applies to Service Type: LoadBalancer. This feature depends on whether the underlying cloud-provider supports specifying 
    #the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature.
    loadBalancerIP: ""
    # -- If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer 
    #will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature.
    loadBalancerSourceRanges: []
    # -- loadBalancerClass is the class of the load balancer implementation this Service belongs to. 
    #If specified, the value of this field must be a label-style identifier, with an optional prefix, e.g. "internal-vip" or 
    #"example.com/internal-vip". Unprefixed names are reserved for end-users. This field can only be set when the Service type is 'LoadBalancer'. 
    #If not set, the default load balancer implementation is used, today this is typically done through the cloud provider integration, 
    #but should apply for any default implementation. If set, it is assumed that a load balancer implementation is watching for Services 
    #with a matching class. Any default load balancer implementation (e.g. cloud providers) should ignore Services that set this field. 
    #This field can only be set when creating or updating a Service to type 'LoadBalancer'. Once set, it can not be changed. 
    #This field will be wiped when a service is updated to a non 'LoadBalancer' type.
    loadBalancerClass: ""
    # -- Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. 
    #Must be ClientIP or None. Defaults to None. More info: 
    #https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
    sessionAffinity: None
    # -- Port of service in Kubernetes cluster
    port: 10050
    # -- NodePort port to allocate on each node (only if service.type = NodePort or Loadbalancer)
    nodePort: 31050

zabbixWeb:
  service:
    # -- Type of service to expose the application. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. 
    #More details: https://kubernetes.io/docs/concepts/services-networking/service/
    type: ClusterIP
    # -- clusterIP is the IP address of the service and is usually assigned randomly. 
    #If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service.
    clusterIP:
    # -- externalTrafficPolicy describes how nodes distribute service traffic they receive on one of the Service's "externally-facing" addresses 
    #(NodePorts, ExternalIPs, and LoadBalancer IPs). "Local" to preserve sender's IP address. Please note that this might not work on multi-node clusters, 
    #depending on your network settings.
    #externalTrafficPolicy: Local
    # -- externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service. 
    #These IPs are not managed by Kubernetes.
    externalIPs: []
    # -- Only applies to Service Type: LoadBalancer. This feature depends on whether the underlying cloud-provider supports specifying 
    #the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature.
    loadBalancerIP: ""
    # -- If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer 
    #will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature.
    loadBalancerSourceRanges: []
    # -- loadBalancerClass is the class of the load balancer implementation this Service belongs to. 
    #If specified, the value of this field must be a label-style identifier, with an optional prefix, e.g. "internal-vip" or 
    #"example.com/internal-vip". Unprefixed names are reserved for end-users. This field can only be set when the Service type is 'LoadBalancer'. 
    #If not set, the default load balancer implementation is used, today this is typically done through the cloud provider integration, 
    #but should apply for any default implementation. If set, it is assumed that a load balancer implementation is watching for Services 
    #with a matching class. Any default load balancer implementation (e.g. cloud providers) should ignore Services that set this field. 
    #This field can only be set when creating or updating a Service to type 'LoadBalancer'. Once set, it can not be changed. 
    #This field will be wiped when a service is updated to a non 'LoadBalancer' type.
    loadBalancerClass: ""
    # -- Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. 
    #Must be ClientIP or None. Defaults to None. More info: 
    #https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
    sessionAffinity: None    # -- Port of service in Kubernetes cluster
    port: 80
    # -- NodePort port to allocate on each node (only if service.type = NodePort or Loadbalancer)
    nodePort: 31080

zabbixWebService:
  service:
    # -- Type of service to expose the application. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. 
    #More details: https://kubernetes.io/docs/concepts/services-networking/service/
    type: ClusterIP
    # -- clusterIP is the IP address of the service and is usually assigned randomly. If an address is specified manually, 
    #is in-range (as per system configuration), and is not in use, it will be allocated to the service.
    clusterIP:
    # -- Port of service in Kubernetes cluster
    port: 10053

zabbixJavaGateway:
  service:
    # -- Type of service to expose the application. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. 
    #More details: https://kubernetes.io/docs/concepts/services-networking/service/
    type: ClusterIP
    # -- clusterIP is the IP address of the service and is usually assigned randomly. 
    #If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service.
    clusterIP:
    # -- externalTrafficPolicy describes how nodes distribute service traffic they receive on one of the Service's "externally-facing" addresses 
    #(NodePorts, ExternalIPs, and LoadBalancer IPs). "Local" to preserve sender's IP address. Please note that this might not work on multi-node clusters, 
    #depending on your network settings.
    #externalTrafficPolicy: Local
    # -- externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service. 
    #These IPs are not managed by Kubernetes.
    externalIPs: []
    # -- Only applies to Service Type: LoadBalancer. This feature depends on whether the underlying cloud-provider supports specifying 
    #the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature.
    loadBalancerIP: ""
    # -- If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer 
    #will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature.
    loadBalancerSourceRanges: []
    # -- loadBalancerClass is the class of the load balancer implementation this Service belongs to. 
    #If specified, the value of this field must be a label-style identifier, with an optional prefix, e.g. "internal-vip" or 
    #"example.com/internal-vip". Unprefixed names are reserved for end-users. This field can only be set when the Service type is 'LoadBalancer'. 
    #If not set, the default load balancer implementation is used, today this is typically done through the cloud provider integration, 
    #but should apply for any default implementation. If set, it is assumed that a load balancer implementation is watching for Services 
    #with a matching class. Any default load balancer implementation (e.g. cloud providers) should ignore Services that set this field. 
    #This field can only be set when creating or updating a Service to type 'LoadBalancer'. Once set, it can not be changed. 
    #This field will be wiped when a service is updated to a non 'LoadBalancer' type.
    loadBalancerClass: ""
    # -- Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. 
    #Must be ClientIP or None. Defaults to None. More info: 
    #https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
    sessionAffinity: None
    # -- Port of service in Kubernetes cluster
    port: 10052
    # -- NodePort port to allocate on each node (only if service.type = NodePort or Loadbalancer)
    nodePort: 31052
```

#### Which issue this PR fixes
  - related this topic https://github.com/zabbix-community/helm-zabbix/discussions/27

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/zabbix-community/helm-zabbix/blob/master/CONTRIBUTING.md) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
