### PR TITLE
Add support for browser monitoring

### DIFF
--- a/charts/zabbix/templates/deployment-webdriver.yaml
+++ b/charts/zabbix/templates/deployment-webdriver.yaml
@@ -1,0 +1,32 @@
+{{- if and .Values.zabbixBrowserMonitoring.enabled .Values.zabbixBrowserMonitoring.webdriver.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "zabbix.fullname" . }}-{{ .Values.zabbixBrowserMonitoring.webdriver.name }}
+  labels:
+    app: {{ template "zabbix.name" . }}
+    release: {{ .Release.Name }}
+    component: webdriver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "zabbix.name" . }}
+      component: webdriver
+  template:
+    metadata:
+      labels:
+        app: {{ template "zabbix.name" . }}
+        component: webdriver
+    spec:
+      containers:
+      - name: {{ .Values.zabbixBrowserMonitoring.webdriver.name }}
+        imagePullPolicy: {{ .Values.zabbixBrowserMonitoring.webdriver.image.pullPolicy }}
+        image: {{ .Values.zabbixBrowserMonitoring.webdriver.image.repository }}:{{ .Values.zabbixBrowserMonitoring.webdriver.image.tag }}
+        ports:
+        - containerPort: {{ .Values.zabbixBrowserMonitoring.webdriver.port }}
+{{- end }}
+      imagePullSecrets:
+      {{- range .Values.zabbixBrowserMonitoring.webdriver.pullSecrets }}
+        - name: {{ . | quote }}
+      {{- end }}

--- a/charts/zabbix/templates/deployment-zabbix-server.yaml
+++ b/charts/zabbix/templates/deployment-zabbix-server.yaml
@@ -159,6 +159,17 @@ spec:
             - name: ZBX_STARTJAVAPOLLERS
               value: {{ .Values.zabbixJavaGateway.ZBX_STARTJAVAPOLLERS | quote }}
             {{- end }}
+            {{- if .Values.zabbixBrowserMonitoring.enabled }}
+            - name: ZBX_STARTBROWSERPOLLERS
+              value: {{ .Values.zabbixBrowserMonitoring.pollers | quote }}
+            {{- end }}
+            {{- if .Values.zabbixBrowserMonitoring.customWebDriverURL }}
+            - name: ZBX_WEBDRIVERURL
+              value: {{ .Values.zabbixBrowserMonitoring.customWebDriverURL | quote }}
+            {{- else }}
+            - name: ZBX_WEBDRIVERURL
+              value: http://{{ template "zabbix.fullname" . }}-{{ .Values.zabbixBrowserMonitoring.webdriver.name }}:{{ .Values.zabbixBrowserMonitoring.webdriver.port }}
+            {{- end }}
           {{- with .Values.zabbixServer.extraVolumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}

--- a/charts/zabbix/templates/service.yaml
+++ b/charts/zabbix/templates/service.yaml
@@ -334,3 +334,23 @@ spec:
   selector:
     app: {{ template "zabbix.fullname" . }}-{{ .Values.zabbixJavaGateway.ZBX_JAVAGATEWAY }}
 {{- end }}
+---
+{{- if and .Values.zabbixBrowserMonitoring.enabled .Values.zabbixBrowserMonitoring.webdriver.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "zabbix.fullname" . }}-{{ .Values.zabbixBrowserMonitoring.webdriver.name }}
+  labels:
+    app: {{ template "zabbix.name" . }}
+    release: {{ .Release.Name }}
+    component: webdriver
+spec:
+  ports:
+    - port: {{ .Values.zabbixBrowserMonitoring.webdriver.port }}
+      targetPort: {{ .Values.zabbixBrowserMonitoring.webdriver.port }}
+      protocol: TCP
+  selector:
+    app: {{ template "zabbix.name" . }}
+    component: webdriver
+  type: ClusterIP
+{{- end }}

--- a/charts/zabbix/values.yaml
+++ b/charts/zabbix/values.yaml
@@ -795,6 +795,39 @@ zabbixJavaGateway:
     failureThreshold: 5
     successThreshold: 1
 
+# Zabbix Browser Monitoring, supported since 7.0.
+# See https://assets.zabbix.com/files/events/2024/conference_benelux_2024/KasparsM_browser_monitoring.pdf
+# and https://www.zabbix.com/documentation/current/en/manual/config/items/itemtypes/browser
+zabbixBrowserMonitoring:
+  # -- Enable browser pollers
+  enabled: false
+
+  # -- Number of browser pollers to start
+  pollers: 1
+
+  webdriver:
+    # -- Enable webdriver
+    enabled: true
+
+    # -- WebDriver container name
+    name: chrome
+    
+    image:
+      # -- WebDriver container image
+      repository: selenium/standalone-chrome
+      # -- WebDriver container image tag, See https://hub.docker.com/r/selenium/standalone-chrome/tags
+      tag: 127.0-chromedriver-127.0-grid-4.23.0-20240727
+      # -- Pull policy of Docker image
+      pullPolicy: IfNotPresent
+      # -- List of dockerconfig secrets names to use when pulling images
+      pullSecrets: []
+
+    # -- WebDriver container port
+    port: 4444
+
+  # -- Custom WebDriver URL. If set, it overrides the default internal WebDriver service URL. Set zabbixBrowserMonitoring.webdriver.enabled to false when setting this.
+  customWebDriverURL: ""
+
 # Ingress configurations
 ingress:
   # -- Enables Ingress


### PR DESCRIPTION
This has been introduced into Zabbix 7.0 to support running Selenium based
website monitoring. For this to work, you need a running webdriver and web browser.
This is now integrated into the chart and can be enabled using `--set zabbixBrowserMonitoring.enabled=true`

Furthermore, it allows referencing a `customWebDriverURL` when an existing
Selenium grid is already set up and can be used.

#### What this PR does / why we need it:

See https://assets.zabbix.com/files/events/2024/conference_benelux_2024/KasparsM_browser_monitoring.pdf

#### Special notes for your reviewer:


#### Checklist
- [x] [DCO](https://github.com/zabbix-community/helm-zabbix/blob/master/CONTRIBUTING.md) signed
- [x] Variables are documented in the README.md
