### PR TITLE
Fix proxy volumes

### DIFF
--- a/charts/zabbix/templates/statefulset-zabbix-proxy.yaml
+++ b/charts/zabbix/templates/statefulset-zabbix-proxy.yaml
@@ -199,8 +199,8 @@ spec:
       {{- range .Values.zabbixProxy.image.pullSecrets }}
         - name: {{ . | quote }}
       {{- end }}
-      {{- with .Values.zabbixProxy.extraVolumes }}
       volumes:
+      {{- with .Values.zabbixProxy.extraVolumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.zabbixAgent.extraVolumes }}


### PR DESCRIPTION
#### What this PR does / why we need it:

When zabbixAgent has extraVolumes values, but zabbixProxy has not, the generated zabbix proxy manifest is invalid:

      imagePullSecrets:
        - configMap:
            name: userparameters
          name: userparameters-volume


(_volume:_ yaml name is missing)

#### Which issue this PR fixes
  - fixes #110

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/zabbix-community/helm-zabbix/blob/master/CONTRIBUTING.md) signed
