### PR TITLE
Make unifiedSecret keys configurable, support setting of non-"public" Postgres Schema

### DIFF
--- a/charts/zabbix/templates/_helpers.tpl
+++ b/charts/zabbix/templates/_helpers.tpl
@@ -109,6 +109,7 @@ Return the entire logic of setting PostgreSQL access related env vars for the co
 {{- $uservar := "POSTGRES_USER" }}
 {{- $passwordvar := "POSTGRES_PASSWORD" }}
 {{- $dbvar := "POSTGRES_DB" }}
+{{- $schemavar := "DB_SERVER_SCHEMA" }}
 {{/* special settings for the DB client (autoclean cron job) container, needs different env variable names */}}
 {{- if eq $cntxt "db_client" }}
 {{- $hostvar = "PGHOST" }}
@@ -128,12 +129,12 @@ Return the entire logic of setting PostgreSQL access related env vars for the co
   valueFrom:
     secretKeyRef:
       name: {{ .Values.postgresAccess.unifiedSecretName }}
-      key: host
+      key: {{ .Values.postgresAccess.unifiedSecretHostKey }}
 - name: {{ $portvar }}
   valueFrom:
     secretKeyRef:
       name: {{ .Values.postgresAccess.unifiedSecretName }}
-      key: port
+      key: {{ .Values.postgresAccess.unifiedPortKey }}
       optional: true
 {{- else }}
 - name: {{ $hostvar }}
@@ -146,19 +147,25 @@ Return the entire logic of setting PostgreSQL access related env vars for the co
   valueFrom:
     secretKeyRef:
       name: {{ .Values.postgresAccess.unifiedSecretName }}
-      key: user
+      key: {{ .Values.postgresAccess.unifiedSecretUserKey }}
       optional: true
 - name: {{ $passwordvar }}
   valueFrom:
     secretKeyRef:
       name: {{ .Values.postgresAccess.unifiedSecretName }}
-      key: password
+      key: {{ .Values.postgresAccess.unifiedSecretPasswordKey }}
 - name: {{ $dbvar }}
   valueFrom:
     secretKeyRef:
       name: {{ .Values.postgresAccess.unifiedSecretName }}
-      key: dbname
+      key: {{ .Values.postgresAccess.unifiedSecretDBKey }}
       optional: true
+{{- if and (not .Values.postgresql.enabled) .Values.postgresAccess.unifiedSecretSchemaKey }}
+- name: {{ $schemavar }}
+  valueFrom:
+      name: {{ .Values.postgresAccess.unifiedSecretName }}
+      key: {{ .Values.postgresAccess.unifiedSecretSchemaKey }}
+{{- end }}
 {{- else }}
 - name: {{ $uservar }}
   value: {{ .Values.postgresAccess.user | quote }}
@@ -173,6 +180,10 @@ Return the entire logic of setting PostgreSQL access related env vars for the co
   {{- end }}
 - name: {{ $dbvar }}
   value: {{ .Values.postgresAccess.database | quote }}
+{{- if and (not .Values.postgresql.enabled) .Values.postgresAccess.schema }}
+- name: {{ $schemavar }}
+  value: {{ .Values.postgresAccess.schema }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end -}}

--- a/charts/zabbix/templates/_helpers.tpl
+++ b/charts/zabbix/templates/_helpers.tpl
@@ -134,7 +134,7 @@ Return the entire logic of setting PostgreSQL access related env vars for the co
   valueFrom:
     secretKeyRef:
       name: {{ .Values.postgresAccess.unifiedSecretName }}
-      key: {{ .Values.postgresAccess.unifiedPortKey }}
+      key: {{ .Values.postgresAccess.unifiedSecretPortKey }}
       optional: true
 {{- else }}
 - name: {{ $hostvar }}
@@ -163,6 +163,7 @@ Return the entire logic of setting PostgreSQL access related env vars for the co
 {{- if and (not .Values.postgresql.enabled) .Values.postgresAccess.unifiedSecretSchemaKey }}
 - name: {{ $schemavar }}
   valueFrom:
+    secretKeyRef:
       name: {{ .Values.postgresAccess.unifiedSecretName }}
       key: {{ .Values.postgresAccess.unifiedSecretSchemaKey }}
 {{- end }}

--- a/charts/zabbix/templates/configmap-zabbix-server-init-waitschema.yaml
+++ b/charts/zabbix/templates/configmap-zabbix-server-init-waitschema.yaml
@@ -147,7 +147,7 @@ data:
 
             if [ -n "${DBVERSION_TABLE_EXISTS}" ]; then
                 echo "** Table '${DB_SERVER_DBNAME}.dbversion' exists."
-                ZBX_DB_VERSION=$(psql_query "SELECT mandatory FROM dbversion" "${DB_SERVER_DBNAME}")
+                ZBX_DB_VERSION=$(psql_query "SELECT mandatory FROM ${DB_SERVER_SCHEMA}.dbversion" "${DB_SERVER_DBNAME}")
             fi
 
             if [ -n "${ZBX_DB_VERSION}" ]; then
@@ -181,7 +181,7 @@ data:
                 if [ ${ZBX_SRV_VERSION_MAJOR} -eq ${ZBX_DB_VERSION_MAJOR} ]; then
                     echo "** schema is the appropriate version, continuing checks"
 
-                    DB_AMOUNT_USERS=$(psql_query "SELECT count(*) FROM users" "${DB_SERVER_DBNAME}")
+                    DB_AMOUNT_USERS=$(psql_query "SELECT count(*) FROM ${DB_SERVER_SCHEMA}.users" "${DB_SERVER_DBNAME}")
                     if [ ${DB_AMOUNT_USERS} -gt 0 ]; then
                         echo "** amount of users in users table is ${DB_AMOUNT_USERS}, letting the Zabbix Server container start"
                         break

--- a/charts/zabbix/templates/deployment-zabbix-server.yaml
+++ b/charts/zabbix/templates/deployment-zabbix-server.yaml
@@ -105,6 +105,9 @@ spec:
           {{- end }}
           env:
             {{- include "zabbix.postgresAccess.variables" (list $ . "zabbix") | nindent 12 }}
+            {{- with .Values.zabbixServer.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           securityContext:
             {{- toYaml .Values.zabbixServer.securityContext | nindent 12 }}
           resources:

--- a/charts/zabbix/templates/secret-db-access.yaml
+++ b/charts/zabbix/templates/secret-db-access.yaml
@@ -21,7 +21,7 @@ data:
   {{- $secretUser := (get $secretData .Values.postgresAccess.unifiedSecretUserKey) | default (default "zabbix" .Values.postgresAccess.user | b64enc) }}
   {{- $secretPassword := (get $secretData .Values.postgresAccess.unifiedSecretPasswordKey) | default (default (randAlphaNum 16) .Values.postgresAccess.password | b64enc) }}
   {{- $secretSchema := "" }}
-  {{- if .Values.postgresAccess.unifiedSecretSchemaKey }}
+  {{- if and (not .Values.postgresql.enabled) .Values.postgresAccess.unifiedSecretSchemaKey }}
   {{- $secretSchema = (get $secretData .Values.postgresAccess.unifiedSecretSchemaKey) | default (default "public" .Values.postgresAccess.schema | b64enc )}}
   {{- end }}
   {{ .Values.postgresAccess.unifiedSecretHostKey }}: {{ $secretHost | quote }}

--- a/charts/zabbix/templates/secret-db-access.yaml
+++ b/charts/zabbix/templates/secret-db-access.yaml
@@ -22,7 +22,7 @@ data:
   {{- $secretPassword := (get $secretData .Values.postgresAccess.unifiedSecretPasswordKey) | default (default (randAlphaNum 16) .Values.postgresAccess.password | b64enc) }}
   {{- $secretSchema := "" }}
   {{- if .Values.postgresAccess.unifiedSecretSchemaKey }}
-  {{- $secretSchema = (get $secretData .Values.postgresAccess.unifiedSecretSchemaKey) | default (default "" (.Values.postgresAccess.schema | b64enc)) }}
+  {{- $secretSchema = (get $secretData .Values.postgresAccess.unifiedSecretSchemaKey) | default (default "public" .Values.postgresAccess.schema | b64enc )}}
   {{- end }}
   {{ .Values.postgresAccess.unifiedSecretHostKey }}: {{ $secretHost | quote }}
   {{ .Values.postgresAccess.unifiedSecretPortKey }}: {{ $secretPort | quote }}

--- a/charts/zabbix/templates/secret-db-access.yaml
+++ b/charts/zabbix/templates/secret-db-access.yaml
@@ -15,14 +15,21 @@ type: Opaque
 data:
   {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace .Values.postgresAccess.unifiedSecretName) | default dict }}
   {{- $secretData := (get $secretObj "data") | default dict }}
-  {{- $secretHost := (get $secretData "host") | default (default (printf "%s-%s" (include "zabbix.fullname" .) "postgresql") .Values.postgresAccess.host | b64enc) }}
-  {{- $secretPort := (get $secretData "port") | default (.Values.postgresql.service.port | toString | b64enc) }}
-  {{- $secretDbname := (get $secretData "dbname") | default ( default "zabbix" .Values.postgresAccess.database | b64enc) }}
-  {{- $secretUser := (get $secretData "user") | default (default "zabbix" .Values.postgresAccess.user | b64enc) }}
-  {{- $secretPassword := (get $secretData "password") | default (default (randAlphaNum 16) .Values.postgresAccess.password | b64enc) }}
-  host: {{ $secretHost | quote }}
-  port: {{ $secretPort | quote }}
-  dbname: {{ $secretDbname | quote }}
-  user: {{ $secretUser | quote }}
-  password: {{ $secretPassword | quote }}
+  {{- $secretHost := (get $secretData .Values.postgresAccess.unifiedSecretHostKey) | default (default (printf "%s-%s" (include "zabbix.fullname" .) "postgresql") .Values.postgresAccess.host | b64enc) }}
+  {{- $secretPort := (get $secretData .Values.postgresAccess.unifiedSecretPortKey) | default (.Values.postgresql.service.port | toString | b64enc) }}
+  {{- $secretDbname := (get $secretData .Values.postgresAccess.unifiedSecretDBKey) | default ( default "zabbix" .Values.postgresAccess.database | b64enc) }}
+  {{- $secretUser := (get $secretData .Values.postgresAccess.unifiedSecretUserKey) | default (default "zabbix" .Values.postgresAccess.user | b64enc) }}
+  {{- $secretPassword := (get $secretData .Values.postgresAccess.unifiedSecretPasswordKey) | default (default (randAlphaNum 16) .Values.postgresAccess.password | b64enc) }}
+  {{- $secretSchema := "" }}
+  {{- if .Values.postgresAccess.unifiedSecretSchemaKey }}
+  {{- $secretSchema = (get $secretData .Values.postgresAccess.unifiedSecretSchemaKey) | default (default "" (.Values.postgresAccess.schema | b64enc)) }}
+  {{- end }}
+  {{ .Values.postgresAccess.unifiedSecretHostKey }}: {{ $secretHost | quote }}
+  {{ .Values.postgresAccess.unifiedSecretPortKey }}: {{ $secretPort | quote }}
+  {{ .Values.postgresAccess.unifiedSecretDBKey }}: {{ $secretDbname | quote }}
+  {{ .Values.postgresAccess.unifiedSecretUserKey }}: {{ $secretUser | quote }}
+  {{ .Values.postgresAccess.unifiedSecretPasswordKey }}: {{ $secretPassword | quote }}
+  {{- if $secretSchema }}
+  {{ .Values.postgresAccess.unifiedSecretSchemaKey }}: {{ $secretSchema | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/zabbix/values.yaml
+++ b/charts/zabbix/values.yaml
@@ -31,20 +31,27 @@ postgresAccess:
   # All relevant components installed by this chart will respect it: zabbixServer, zabbixWeb and postgresql (if enabled)
   #
   # USING ONE SECRET CONTAINING ALL DB RELEVANT SETTINGS
-  # PostgreSQL access details all in one existing secret (matches the structure of secrets the CrunchyData pgo operator generates)
+  # PostgreSQL access details all in one existing secret (matches the structure of secrets the CrunchyData PGO operator 
+  # and the CNPG postgres operator generate)
   # if this option is chosen the below listed settings are being ignored
-  # the secret must contain the following keys:
-  #   * host
-  #   * port
-  #   * user
-  #   * password
-  #   * dbname
   # -- Whether to use the unified PostgreSQL access secret
   useUnifiedSecret: true
   # -- Name of one secret for unified configuration of PostgreSQL access
   unifiedSecretName: zabbixdb-pguser-zabbix
   # -- automatically create secret if not already present (works only in combination with postgresql.enabled=true)
   unifiedSecretAutoCreate: true
+  # -- key of the unified postgres access secret where host ip / dns name for the postgres db is found
+  unifiedSecretHostKey: host
+  # -- key of the unified postgres access secret where the port for the postgres db is found
+  unifiedSecretPortKey: port
+  # -- key of the unified postgres access secret where user name for the postgres db is found
+  unifiedSecretUserKey: user
+  # -- key of the unified postgres access secret where password for the postgres db is found
+  unifiedSecretPasswordKey: password
+  # -- key of the unified postgres access secret where database name for the postgres db is found
+  unifiedSecretDBKey: dbname
+  # -- key of the unified postgres access secret where schema name for the postgres db is found. Can be left empty (defaults to "public", then)
+  unifiedSecretSchemaKey: ""
   #
   # If you do NOT want to use one unified secret for all settings, you can still set the credentials manually here.
   # These settings will be used for all components of this chart where it makes sense (zabbix server, postgresql,
@@ -63,6 +70,8 @@ postgresAccess:
   password: "zabbix"
   # -- Name of database
   database: "zabbix"
+  # -- Schema of database. Can be left empty if unifiedSecretSchemaKey is not set
+  schema: ""
 
 # **Zabbix Server** configurations
 zabbixServer:

--- a/charts/zabbix/values.yaml
+++ b/charts/zabbix/values.yaml
@@ -50,7 +50,7 @@ postgresAccess:
   unifiedSecretPasswordKey: password
   # -- key of the unified postgres access secret where database name for the postgres db is found
   unifiedSecretDBKey: dbname
-  # -- key of the unified postgres access secret where schema name for the postgres db is found. Can be left empty (defaults to "public", then)
+  # -- key of the unified postgres access secret where schema name for the postgres db is found. Can be left empty (defaults to "public", then). Only being used if external database is used (`postgresql.enabled` not set) 
   unifiedSecretSchemaKey: ""
   #
   # If you do NOT want to use one unified secret for all settings, you can still set the credentials manually here.
@@ -70,7 +70,7 @@ postgresAccess:
   password: "zabbix"
   # -- Name of database
   database: "zabbix"
-  # -- Schema of database. Can be left empty if unifiedSecretSchemaKey is not set
+  # -- Schema of database. Can be left empty if unifiedSecretSchemaKey is not set. Only being used if external database is used (`postgresql.enabled` not set)
   schema: ""
 
 # **Zabbix Server** configurations


### PR DESCRIPTION
Instead of hardcoding the keys for the "unifiedSecret" to access the Postgresql database, I have made all of them configurable, to also work with possible other database operators other than CNPG and PGO, and any already existing secret containing database connection related settings. Due to the newly introduced values, there is no blocking change for existing users, as I do default back to the formerly hardcoded keys.

Additionally to that, I have made the postgresql "schema" configurable, for both methods using the unified secret or supplying the database related configuration settings directly in `values.yaml`. The support of a **schema** other than "public" is only available when `.Values.postgresql.enabled` is set to ``false``, meaning an external (already existing) database is being used. The reason for that is that the official **postgres** image does not support setting a schema, so it doesn't make sense to have it configured for Zabbix in such a setup, either.

I have done tests with and without native Zabbix Server High Availability enabled and made sure the schema setting works in both cases.

#### Which issue this PR fixes
* fixes #120 
* fixes #122 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/zabbix-community/helm-zabbix/blob/master/CONTRIBUTING.md) signed
- [ ] Chart Version bumped
- [x] Variables are documented in the README.md
