### PR TITLE
set ZBX_NODEADDRESS of zabbix server pod even with HA mode disabled

### DIFF
--- a/charts/zabbix/templates/deployment-zabbix-server.yaml
+++ b/charts/zabbix/templates/deployment-zabbix-server.yaml
@@ -152,11 +152,11 @@ spec:
             {{- if .Values.zabbixServer.zabbixServerHA.enabled }}
             - name: ZBX_AUTOHANODENAME
               value: "hostname"
+            {{- end }}
             - name: ZBX_NODEADDRESS
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            {{- end }}
             {{- if .Values.zabbixWebService.enabled }}
             - name: ZBX_WEBSERVICEURL
               value: "http://{{ template "zabbix.fullname" . }}-zabbix-webservice:{{ .Values.zabbixWebService.service.port }}/report"


### PR DESCRIPTION
When changing the structure of the Helm Chart to allow Zabbix Server HA mode to be disabled, I missed the fact that still the environment variable `ZBX_NODEADDRESS` has to be set to a proper IP or host name under which the Zabbix Server will be reachable from the web frontend. Only the `ZBX_HANODENAME` actually switches HA mode on and off by being set or not set.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/zabbix-community/helm-zabbix/blob/main/CONTRIBUTING.md) signed
- [x] Variables are documented in values.yaml with [Helm-Docs](https://github.com/norwoodj/helm-docs) comments, as we build README.md using this utility
