### PR TITLE
Feature/agent daemonset hostnet

### DIFF
--- a/charts/zabbix/README.md
+++ b/charts/zabbix/README.md
@@ -415,6 +415,7 @@ The following tables lists the configurable parameters of the chart and their de
 | zabbixAgent.readinessProbe | object | `{}` | The kubelet uses readiness probes to know when a container is ready to start accepting traffic. Reference: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/ |
 | zabbixAgent.resources | object | `{}` | Requests and limits of pod resources. See: [https://kubernetes.io/docs/concepts/configuration/manage-resources-containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers) |
 | zabbixAgent.runAsDaemonSet | bool | `false` | Enable this mode if you want to run zabbix-agent as daemonSet. The 'zabbixAgent.runAsSidecar' option must be false. |
+| zabbixAgent.hostNetwork | bool | `false` | Enable this mode if you want to run zabbix-agent daemonSet on the host network. |
 | zabbixAgent.runAsSidecar | bool | `true` | Its is a default mode. Zabbix-agent will run as sidecar in zabbix-server and zabbix-proxy pods. Disable this mode if you want to run zabbix-agent as daemonSet |
 | zabbixAgent.securityContext | object | `{}` | Security Context configurations. Reference: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
 | zabbixAgent.service.annotations | object | `{}` | Annotations for the zabbix-agent service |

--- a/charts/zabbix/templates/daemonset-zabbix-agent.yaml
+++ b/charts/zabbix/templates/daemonset-zabbix-agent.yaml
@@ -36,6 +36,7 @@ spec:
         {{- toYaml .Values.zabbixAgent.containerLabels | nindent 8 }}
         {{- end }}
     spec:
+      hostNetwork:  {{ .Values.zabbixAgent.hostNetwork }}
       serviceAccountName: {{ template "zabbix.serviceAccountName" . }}
       {{- with .Values.zabbixAgent.extraPodSpecs }}
       {{- toYaml . | nindent 6 }}

--- a/charts/zabbix/values.yaml
+++ b/charts/zabbix/values.yaml
@@ -449,6 +449,8 @@ zabbixAgent:
   runAsSidecar: true
   # -- Enable this mode if you want to run zabbix-agent as daemonSet. The 'zabbixAgent.runAsSidecar' option must be false.
   runAsDaemonSet: false
+  # -- Run Daemonset on host network
+  hostNetwork: false
   # -- Requests and limits of pod resources. See: [https://kubernetes.io/docs/concepts/configuration/manage-resources-containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers)
   resources: {}
   image:


### PR DESCRIPTION
### What this PR does / why we need it:
This PR introduces a new boolean variable, `zabbixAgent.hostNetwork`, to the chart values. This allows users to enable the host network for Zabbix agents when running them as a DaemonSet. 

In our setup, the Zabbix server runs outside the Kubernetes cluster, while proxies and agents are deployed within the cluster. When running agents as a DaemonSet, proxies cannot retrieve passive check data from the agents unless the agents are configured to use the host network. This change makes it possible to set `hostNetwork: true` directly from the chart values, simplifying deployment configuration.

### Checklist
- [x] [[DCO](https://github.com/zabbix-community/helm-zabbix/blob/main/CONTRIBUTING.md)](https://github.com/zabbix-community/helm-zabbix/blob/main/CONTRIBUTING.md) signed  
- [x] Variables are documented in `values.yaml` with [[Helm-Docs](https://github.com/norwoodj/helm-docs)](https://github.com/norwoodj/helm-docs) comments, as we build `README.md` using this utility  
