### PR TITLE
Fixed pullSecrets values field for webdriver deployment

### DIFF
--- a/charts/zabbix/templates/deployment-webdriver.yaml
+++ b/charts/zabbix/templates/deployment-webdriver.yaml
@@ -26,7 +26,7 @@ spec:
         ports:
         - containerPort: {{ .Values.zabbixBrowserMonitoring.webdriver.port }}
       imagePullSecrets:
-      {{- range .Values.zabbixBrowserMonitoring.webdriver.pullSecrets }}
+      {{- range .Values.zabbixBrowserMonitoring.webdriver.image.pullSecrets }}
         - name: {{ . | quote }}
       {{- end }}
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Currently, the `webdriver` deployment ignores setting `pullSecrets` in `.Values.zabbixBrowserMonitoring.webdriver.image.pullSecrets` because of a misconfiguration in the Helm template. Specifically, the template incorrectly iterates over `.Values.zabbixBrowserMonitoring.webdriver.pullSecrets` instead of `.Values.zabbixBrowserMonitoring.webdriver.image.pullSecrets`.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x ] [DCO](https://github.com/zabbix-community/helm-zabbix/blob/main/CONTRIBUTING.md) signed