### PR TITLE
Change post-install to pre-install for create-upgrade-db job

### DIFF
--- a/charts/zabbix/templates/job-create-upgrade-db.yaml
+++ b/charts/zabbix/templates/job-create-upgrade-db.yaml
@@ -17,7 +17,7 @@ metadata:
     {{- toYaml .Values.zabbixServer.zabbixServerHA.dbCreateUpgradeJob.jobLabels | nindent 6 }}
     {{- end }}
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook": pre-install,post-upgrade
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": hook-succeeded
     {{- range $key,$value := .Values.zabbixServer.zabbixServerHA.dbCreateUpgradeJob.jobAnnotations }}


### PR DESCRIPTION
<!--
Thank you for contributing to this repository. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/zabbix-community/helm-zabbix/blob/main/CONTRIBUTING.md
* https://github.com/zabbix-community/helm-zabbix/blob/main/charts/zabbix/docs/requirements.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.
-->

#### What this PR does / why we need it:

I could not get a fresh install running with following helm values (and an external postgresql cluster): 

```
zabbixServer:
  enabled: true
  zabbixServerHA:
    enabled: true
postgresql:
  enabled: false
```

After some investigation, when zabbixServerHA is enabled, the zabbix server pod is waiting to become active with the initContainer `init-wait-for-database-schema`, but the job to create the initial schema has the helm hook set to `post-install`. As the helm installer does not complete because the zabbix server pod does not become active and healthy, it does not work without manually inserting this upgrade-db job.

I believe changing the helm hook annotation from post-install to pre-install will fix this.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/zabbix-community/helm-zabbix/blob/main/CONTRIBUTING.md) signed
- [x] Variables are documented in values.yaml with [Helm-Docs](https://github.com/norwoodj/helm-docs) comments, as we build README.md using this utility
