### PR TITLE
Add namespace declaration to manifests

### DIFF
--- a/charts/zabbix/templates/cronjob-hanodes-autoclean.yaml
+++ b/charts/zabbix/templates/cronjob-hanodes-autoclean.yaml
@@ -3,6 +3,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ template "zabbix.fullname" . }}-nodesclean
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "zabbix.labels" . | nindent 4 }}
     {{- if .Values.zabbixServer.haNodesAutoClean.cronjobLabels }}

--- a/charts/zabbix/templates/daemonset-zabbix-agent.yaml
+++ b/charts/zabbix/templates/daemonset-zabbix-agent.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "zabbix.fullname" . }}-zabbix-agent
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "zabbix.labels" . | nindent 4 }}
     app.kubernetes.io/component: agent

--- a/charts/zabbix/templates/deployment-webdriver.yaml
+++ b/charts/zabbix/templates/deployment-webdriver.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "zabbix.fullname" . }}-{{ .Values.zabbixBrowserMonitoring.webdriver.name }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "zabbix.labels" . | nindent 4 }}
     app.kubernetes.io/component: webdriver

--- a/charts/zabbix/templates/deployment-zabbix-java-gateway.yaml
+++ b/charts/zabbix/templates/deployment-zabbix-java-gateway.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "zabbix.fullname" . }}-{{ .Values.zabbixJavaGateway.ZBX_JAVAGATEWAY }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "zabbix.labels" . | nindent 4 }}
     app.kubernetes.io/component: java-gateway

--- a/charts/zabbix/templates/deployment-zabbix-server.yaml
+++ b/charts/zabbix/templates/deployment-zabbix-server.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "zabbix.fullname" . }}-zabbix-server
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "zabbix.labels" . | nindent 4 }}
     app.kubernetes.io/component: server

--- a/charts/zabbix/templates/deployment-zabbix-web.yaml
+++ b/charts/zabbix/templates/deployment-zabbix-web.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "zabbix.fullname" . }}-zabbix-web
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "zabbix.labels" . | nindent 4 }}
     app.kubernetes.io/component: web

--- a/charts/zabbix/templates/deployment-zabbix-webservice.yaml
+++ b/charts/zabbix/templates/deployment-zabbix-webservice.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "zabbix.fullname" . }}-zabbix-webservice
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "zabbix.labels" . | nindent 4 }}
     app.kubernetes.io/component: webservice

--- a/charts/zabbix/templates/ingress.yaml
+++ b/charts/zabbix/templates/ingress.yaml
@@ -10,6 +10,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "zabbix.labels" . | nindent 4 }}
     app.kubernetes.io/component: web

--- a/charts/zabbix/templates/job-create-upgrade-db.yaml
+++ b/charts/zabbix/templates/job-create-upgrade-db.yaml
@@ -6,6 +6,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "zabbix.fullname" . }}-create-upgrade-db
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "zabbix.labels" . | nindent 4 }}
     app.kubernetes.io/component: create-upgrade-db

--- a/charts/zabbix/templates/role-ha-helper.yaml
+++ b/charts/zabbix/templates/role-ha-helper.yaml
@@ -4,6 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "zabbix.fullname" . }}-ha-helper
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "zabbix.labels" . | nindent 4 }}
   {{- if .Values.zabbixServer.zabbixServerHA.role.annotations }}

--- a/charts/zabbix/templates/rolebinding-ha-helper.yaml
+++ b/charts/zabbix/templates/rolebinding-ha-helper.yaml
@@ -4,6 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "zabbix.fullname" . }}-ha-helper
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "zabbix.labels" . | nindent 4 }}
   {{- if .Values.zabbixServer.zabbixServerHA.roleBinding.annotations }}

--- a/charts/zabbix/templates/secret-db-access.yaml
+++ b/charts/zabbix/templates/secret-db-access.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "zabbix.fullname" . }}-db-access
+  namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/resource-policy": keep
   labels:

--- a/charts/zabbix/templates/service.yaml
+++ b/charts/zabbix/templates/service.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "zabbix.fullname" . }}-zabbix-server
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "zabbix.labels" . | nindent 4 }}
     app.kubernetes.io/component: server
@@ -63,6 +64,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "zabbix.fullname" . }}-zabbix-agent
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "zabbix.labels" . | nindent 4 }}
     app.kubernetes.io/component: agent
@@ -115,6 +117,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "zabbix.fullname" . }}-zabbix-web
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "zabbix.labels" . | nindent 4 }}
     app.kubernetes.io/component: web
@@ -167,6 +170,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "zabbix.fullname" . }}-zabbix-webservice
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "zabbix.labels" . | nindent 4 }}
     app.kubernetes.io/component: webservice
@@ -198,6 +202,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "zabbix.fullname" . }}-zabbix-proxy
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "zabbix.labels" . | nindent 4 }}
     app.kubernetes.io/component: proxy
@@ -250,6 +255,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "zabbix.fullname" . }}-postgresql
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "zabbix.labels" . | nindent 4 }}
     app.kubernetes.io/component: postgresql
@@ -281,6 +287,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "zabbix.fullname" . }}-java-gateway
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "zabbix.labels" . | nindent 4 }}
     app.kubernetes.io/component: java-gateway
@@ -333,6 +340,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "zabbix.fullname" . }}-{{ .Values.zabbixBrowserMonitoring.webdriver.name }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "zabbix.labels" . | nindent 4 }}
     app.kubernetes.io/component: webdriver

--- a/charts/zabbix/templates/serviceaccount-ha-helper.yaml
+++ b/charts/zabbix/templates/serviceaccount-ha-helper.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "zabbix.fullname" . }}-ha-helper
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "zabbix.labels" . | nindent 4 }}
   {{- if .Values.zabbixServer.zabbixServerHA.serviceAccount.annotations }}

--- a/charts/zabbix/templates/serviceaccount.yaml
+++ b/charts/zabbix/templates/serviceaccount.yaml
@@ -8,6 +8,7 @@ imagePullSecrets:
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ template "zabbix.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/zabbix/templates/statefulset-postgresql.yaml
+++ b/charts/zabbix/templates/statefulset-postgresql.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "zabbix.fullname" . }}-postgresql
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "zabbix.labels" . | nindent 4 }}
     app.kubernetes.io/component: postgresql

--- a/charts/zabbix/templates/statefulset-zabbix-proxy.yaml
+++ b/charts/zabbix/templates/statefulset-zabbix-proxy.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "zabbix.fullname" . }}-zabbix-proxy
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "zabbix.labels" . | nindent 4 }}
     app.kubernetes.io/component: proxy

--- a/charts/zabbix/templates/tests/test-server-connection.yaml
+++ b/charts/zabbix/templates/tests/test-server-connection.yaml
@@ -3,6 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "zabbix.fullname" . }}-test-server-connection
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "zabbix.fullname" . }}-test-server-connection
     app.kubernetes.io/name: test-server-connection

--- a/charts/zabbix/templates/tests/test-web-connection.yaml
+++ b/charts/zabbix/templates/tests/test-web-connection.yaml
@@ -3,6 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "zabbix.fullname" . }}-test-web-connection
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "zabbix.fullname" . }}-test-web-connection
     app.kubernetes.io/name: test-web-connection


### PR DESCRIPTION
#### What this PR does / why we need it:

- best practice
- prevent argocd error like "Namespace for $name networking.k8s.io/v1, Kind=Ingress is missing."