### PR TITLE
deployment-webdriver with nodeAffinity

### DIFF
--- a/charts/zabbix/templates/deployment-webdriver.yaml
+++ b/charts/zabbix/templates/deployment-webdriver.yaml
@@ -19,6 +19,15 @@ spec:
         app: {{ template "zabbix.name" . }}
         component: webdriver
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: "kubernetes.io/arch"
+                    operator: In
+                    values:
+                      - amd64
       containers:
       - name: {{ .Values.zabbixBrowserMonitoring.webdriver.name }}
         imagePullPolicy: {{ .Values.zabbixBrowserMonitoring.webdriver.image.pullPolicy }}


### PR DESCRIPTION


**What this PR does**
If the cluster uses nodes with both architectures (ARM64 and AMD64), "nodeAffinity" ensures the pod is scheduled in an AMD64 node. 

**Why we need it**
Because **selenium/standalone-chrome** supports only linux/amd64 (at least for now).
