### PR TITLE
fix: removed global nodeSelector to apply the parameter individually …

### DIFF
--- a/charts/zabbix/templates/cronjob-hanodes-autoclean.yaml
+++ b/charts/zabbix/templates/cronjob-hanodes-autoclean.yaml
@@ -21,7 +21,7 @@ spec:
           {{- with .Values.zabbixServer.haNodesAutoClean.extraPodSpecs }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
-          {{- with .Values.nodeSelector }}
+          {{- with .Values.zabbixServer.nodeSelector }}
           nodeSelector:
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/zabbix/templates/daemonset-zabbix-agent.yaml
+++ b/charts/zabbix/templates/daemonset-zabbix-agent.yaml
@@ -40,7 +40,7 @@ spec:
       {{- with .Values.zabbixAgent.extraPodSpecs }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.zabbixAgent.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/zabbix/templates/deployment-webdriver.yaml
+++ b/charts/zabbix/templates/deployment-webdriver.yaml
@@ -19,6 +19,10 @@ spec:
         {{- include "zabbix.labels" . | nindent 8 }}
         app.kubernetes.io/component: webdriver
     spec:
+      {{- with .Values.zabbixBrowserMonitoring.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Values.zabbixBrowserMonitoring.webdriver.name }}
         imagePullPolicy: {{ .Values.zabbixBrowserMonitoring.webdriver.image.pullPolicy }}

--- a/charts/zabbix/templates/deployment-zabbix-java-gateway.yaml
+++ b/charts/zabbix/templates/deployment-zabbix-java-gateway.yaml
@@ -37,7 +37,7 @@ spec:
       {{- with .Values.zabbixJavaGateway.extraPodSpecs }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.zabbixJavaGateway.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/zabbix/templates/deployment-zabbix-server.yaml
+++ b/charts/zabbix/templates/deployment-zabbix-server.yaml
@@ -62,7 +62,7 @@ spec:
       {{- with .Values.zabbixServer.extraPodSpecs }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.zabbixServer.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/zabbix/templates/deployment-zabbix-web.yaml
+++ b/charts/zabbix/templates/deployment-zabbix-web.yaml
@@ -41,7 +41,7 @@ spec:
       initContainers:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.zabbixWeb.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/zabbix/templates/deployment-zabbix-webservice.yaml
+++ b/charts/zabbix/templates/deployment-zabbix-webservice.yaml
@@ -37,7 +37,7 @@ spec:
       {{- with .Values.zabbixWebService.extraPodSpecs }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.zabbixWebService.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/zabbix/templates/job-create-upgrade-db.yaml
+++ b/charts/zabbix/templates/job-create-upgrade-db.yaml
@@ -28,7 +28,7 @@ spec:
       {{- with .Values.zabbixServer.zabbixServerHA.dbCreateUpgradeJob.extraPodSpecs }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.zabbixServer.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/zabbix/templates/statefulset-postgresql.yaml
+++ b/charts/zabbix/templates/statefulset-postgresql.yaml
@@ -63,7 +63,7 @@ spec:
       initContainers:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.postgresql.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/zabbix/templates/statefulset-zabbix-proxy.yaml
+++ b/charts/zabbix/templates/statefulset-zabbix-proxy.yaml
@@ -53,7 +53,7 @@ spec:
       initContainers:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.zabbixProxy.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/zabbix/templates/tests/test-server-connection.yaml
+++ b/charts/zabbix/templates/tests/test-server-connection.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   template:
     spec:
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.helmTestJobs.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/zabbix/templates/tests/test-web-connection.yaml
+++ b/charts/zabbix/templates/tests/test-web-connection.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   template:
     spec:
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.helmTestJobs.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/zabbix/values.yaml
+++ b/charts/zabbix/values.yaml
@@ -258,6 +258,8 @@ zabbixServer:
   readinessProbe: {}
   # -- The kubelet uses startup probes to know when a container application has started.  Reference: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
   startupProbe: {}
+  # -- nodeSelector configurations. Reference: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+  nodeSelector: {}
 
 # **PostgreSQL** configuration
 postgresql:
@@ -329,6 +331,8 @@ postgresql:
   readinessProbe: {}
   # -- The kubelet uses startup probes to know when a container application has started.  Reference: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
   startupProbe: {}
+  # -- nodeSelector configurations. Reference: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+  nodeSelector: {}
 
 # **Zabbix Proxy** configurations
 zabbixProxy:
@@ -435,6 +439,8 @@ zabbixProxy:
   readinessProbe: {}
   # -- The kubelet uses startup probes to know when a container application has started.  Reference: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
   startupProbe: {}
+  # -- nodeSelector configurations. Reference: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+  nodeSelector: {}
 
 # **Zabbix Agent** configurations
 zabbixAgent:
@@ -562,6 +568,8 @@ zabbixAgent:
     timeoutSeconds: 3
     failureThreshold: 5
     successThreshold: 1
+  # -- nodeSelector configurations. Reference: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+  nodeSelector: {}
 
 # **Zabbix Web** configurations
 zabbixWeb:
@@ -673,6 +681,8 @@ zabbixWeb:
     successThreshold: 1
   # -- The kubelet uses startup probes to know when a container application has started.  Reference: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
   startupProbe: {}
+  # -- nodeSelector configurations. Reference: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+  nodeSelector: {}
 
 # **Zabbix Web Service** configurations
 zabbixWebService:
@@ -735,6 +745,8 @@ zabbixWebService:
   readinessProbe: {}
   # -- The kubelet uses startup probes to know when a container application has started.  Reference: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
   startupProbe: {}
+  # -- nodeSelector configurations. Reference: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+  nodeSelector: {}
 
 # **Zabbix Java Gateway** configurations
 zabbixJavaGateway:
@@ -848,6 +860,8 @@ zabbixJavaGateway:
     timeoutSeconds: 3
     failureThreshold: 5
     successThreshold: 1
+  # -- nodeSelector configurations. Reference: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+  nodeSelector: {}
 
 # Zabbix Browser Monitoring, supported since 7.0.
 # See https://assets.zabbix.com/files/events/2024/conference_benelux_2024/KasparsM_browser_monitoring.pdf
@@ -881,6 +895,8 @@ zabbixBrowserMonitoring:
 
   # -- Custom WebDriver URL. If set, it overrides the default internal WebDriver service URL. Set zabbixBrowserMonitoring.webdriver.enabled to false when setting this.
   customWebDriverURL: ""
+  # -- nodeSelector configurations. Reference: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+  nodeSelector: {}
 
 # Ingress configurations
 ingress:
@@ -906,9 +922,6 @@ ingress:
   # ingressClassName: nginx
   # -- pathType is only for k8s >= 1.1=
   pathType: Prefix
-
-# -- nodeSelector configurations. Reference: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
-nodeSelector: {}
 
 # -- Tolerations configurations. Reference: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
 tolerations: []
@@ -972,3 +985,5 @@ helmTestJobs:
     securityContext: {}
     # -- Resource limits/reservations for Helm test job testing connection to Zabbix server
     resources: {}
+  # -- nodeSelector configurations. Reference: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+  nodeSelector: {}


### PR DESCRIPTION
**What this PR does**
If the cluster uses nodes with both architectures (ARM64 and AMD64), individual "nodeSelector" provides a more granular/flexible way to ensure the pods are scheduled in the desired node.

**Why we need it**
Because selenium/standalone-chrome supports only linux/amd64 (at least for now).

