### PR TITLE
Add Zalando postgres operator support

### DIFF
--- a/charts/zabbix/templates/_helpers.tpl
+++ b/charts/zabbix/templates/_helpers.tpl
@@ -135,17 +135,27 @@ Return the entire logic of setting PostgreSQL access related env vars for the co
 - name: {{ $portvar }}
   value: {{ .Values.postgresAccess.port | quote }}
 {{- else }}
+{{- if and .Values.postgresAccess.existingSecretName .Values.postgresAccess.secretHostKey }}
 - name: {{ $hostvar }}
   valueFrom:
     secretKeyRef:
       name: {{ $secretName }}
       key: {{ .Values.postgresAccess.secretHostKey }}
+{{- else }}
+- name: {{ $hostvar }}
+  value: {{ .Values.postgresAccess.host | quote }}
+{{- end }}
+{{- if and .Values.postgresAccess.existingSecretName .Values.postgresAccess.secretPortKey }}
 - name: {{ $portvar }}
   valueFrom:
     secretKeyRef:
       name: {{ $secretName }}
       key: {{ .Values.postgresAccess.secretPortKey }}
       optional: true
+{{- else }}
+- name: {{ $portvar }}
+  value: {{ .Values.postgresAccess.port | quote }}
+{{- end }}
 {{- end }}
 
 {{- if and (eq $cntxt "db_init_upgrade") (not .Values.postgresAccess.existingSecretName) }}
@@ -171,12 +181,17 @@ Return the entire logic of setting PostgreSQL access related env vars for the co
     secretKeyRef:
       name: {{ $secretName }}
       key: {{ .Values.postgresAccess.secretPasswordKey }}
+{{- if and .Values.postgresAccess.existingSecretName .Values.postgresAccess.secretDBKey }}
 - name: {{ $dbvar }}
   valueFrom:
     secretKeyRef:
       name: {{ $secretName }}
       key: {{ .Values.postgresAccess.secretDBKey }}
       optional: true
+{{- else }}
+- name: {{ $dbvar }}
+  value: {{ .Values.postgresAccess.database | quote }}
+{{- end }}
   {{- if and (not .Values.postgresql.enabled) .Values.postgresAccess.secretSchemaKey }}
 - name: {{ $schemavar }}
   valueFrom:

--- a/charts/zabbix/values.yaml
+++ b/charts/zabbix/values.yaml
@@ -33,18 +33,24 @@ postgresAccess:
   # USING ONE SECRET CONTAINING ALL DB RELEVANT SETTINGS
   # PostgreSQL access details all in one existing secret (matches the structure of secrets the CrunchyData PGO operator
   # and the CNPG postgres operator generate)
+  # for Zalando Postgres operator mixed setup is needed
+  # use Username and password needs to be referenced from secret
+  # host, port and db needs to be filled below
   # if this option is chosen the below listed settings are being ignored
   # -- Name of an existing secret to use for database access. This could be one created by a Postgres operator such as CNPG or PGO
   existingSecretName: ""
   # -- key of the postgres access secret where host ip / dns name for the postgres db is found
+  # if removed postgresAccess.host is used
   secretHostKey: host
   # -- key of the postgres access secret where the port for the postgres db is found
+  # if removed postgresAccess.port is used
   secretPortKey: port
   # -- key of the postgres access secret where user name for the postgres db is found
   secretUserKey: user
   # -- key of the unified postgres access secret where password for the postgres db is found
   secretPasswordKey: password
   # -- key of the postgres access secret where database name for the postgres db is found
+  # if removed postgresAccess.database is used
   secretDBKey: dbname
   # -- key of the postgres access secret where schema name for the postgres db is found. Can be left empty (defaults to "public", then). Only being used if external database is used (`postgresql.enabled` not set)
   secretSchemaKey: ""


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes
  - fixes #184

#### Special notes for your reviewer:
As Zalando postgresql operator stores only db user and password in secret, we need to provide all other values manually. 
https://postgres-operator.readthedocs.io/en/refactoring-sidecars/user/#connect-to-postgresql

No new variables introduced, just added additional if's to mix existingSecret with values provided in `postgresAccess` directly. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/zabbix-community/helm-zabbix/blob/main/CONTRIBUTING.md) signed
- [x] Variables are documented in values.yaml with [Helm-Docs](https://github.com/norwoodj/helm-docs) comments, as we build README.md using this utility
