### PR TITLE
feature: use /ping endpoint for zabbixWeb healthchecks

### DIFF
--- a/charts/zabbix/values.yaml
+++ b/charts/zabbix/values.yaml
@@ -667,7 +667,7 @@ zabbixWeb:
   livenessProbe:
     httpGet:
       # -- Path of health check of application
-      path: /
+      path: /ping
       # -- Port number/alias name of the container
       port: zabbix-web
     initialDelaySeconds: 30
@@ -678,7 +678,7 @@ zabbixWeb:
   readinessProbe:
     httpGet:
       # -- Path of health check of application
-      path: /
+      path: /ping
       # -- Port number/alias name of the container
       port: zabbix-web
     initialDelaySeconds: 5


### PR DESCRIPTION
#### What this PR does / why we need it:
Changes default health check endpoint of Zabbix Web container from `/` to `/ping`.

#### Which issue this PR fixes
* Access logs are disabled for endpoint `/ping`

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/zabbix-community/helm-zabbix/blob/main/CONTRIBUTING.md) signed
- [x] Variables are documented in values.yaml with [Helm-Docs](https://github.com/norwoodj/helm-docs) comments, as we build README.md using this utility
