### PR TITLE
feature: add support for https by adding variable port for Zabbix Web to values.yaml

### DIFF
--- a/charts/zabbix/templates/deployment-zabbix-web.yaml
+++ b/charts/zabbix/templates/deployment-zabbix-web.yaml
@@ -82,7 +82,7 @@ spec:
           {{- end }}
         ports:
           - name: zabbix-web
-            containerPort: 8080
+            containerPort: {{ .Values.zabbixWeb.port }}
             protocol: TCP
         volumeMounts:
         {{- if .Values.zabbixWeb.samlCertsSecretName }}

--- a/charts/zabbix/values.yaml
+++ b/charts/zabbix/values.yaml
@@ -597,6 +597,8 @@ zabbixWeb:
     pullPolicy: IfNotPresent
     # -- List of dockerconfig secrets names to use when pulling images
     pullSecrets: []
+  # -- Port of the Zabbix Web application. Change to 8443 in case of HTTPS. Add certs to samlCertsSecretName.
+  port: 8080
   # -- Secret name containing certificates for SAML configuration. Example: zabbix-web-samlcerts
   samlCertsSecretName: ""
   service:


### PR DESCRIPTION
<!--
Thank you for contributing to this repository. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

- https://github.com/zabbix-community/helm-zabbix/blob/main/CONTRIBUTING.md
- https://github.com/zabbix-community/helm-zabbix/blob/main/charts/zabbix/docs/requirements.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.
-->

#### What this PR does / why we need it:
I need to enable https for Zabbix Web, which is exposed on port 8443. Currently the port of the Zabbix Web container is hard coded. So I added a new variable `port` to make it configurable.

#### Which issue this PR fixes
* Enable usage of port 8443 with https

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/zabbix-community/helm-zabbix/blob/main/CONTRIBUTING.md) signed
- [x] Variables are documented in values.yaml with [Helm-Docs](https://github.com/norwoodj/helm-docs) comments, as we build README.md using this utility
