### PR TITLE
fix: variable name for ZabbisWebService pullsecrets

### DIFF
--- a/charts/zabbix/templates/deployment-zabbix-webservice.yaml
+++ b/charts/zabbix/templates/deployment-zabbix-webservice.yaml
@@ -109,7 +109,7 @@ spec:
       {{- toYaml . | nindent 6 }}
       {{- end }}
       imagePullSecrets:
-      {{- range .Values.zabbixWeb.image.pullSecrets }}
+      {{- range .Values.zabbixWebService.image.pullSecrets }}
         - name: {{ . | quote }}
       {{- end }}
       {{- with .Values.global.imagePullSecrets }}


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes
* Fixes use of wrong variable name (`zabbixWebService` instead of `zabbixWeb`)

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/zabbix-community/helm-zabbix/blob/main/CONTRIBUTING.md) signed
- [x] Variables are documented in values.yaml with [Helm-Docs](https://github.com/norwoodj/helm-docs) comments, as we build README.md using this utility
