### PR TITLE
Many improvement in zabbix-webdriver, add support to zabbix 7.4.0, new release and adjusts in doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,7 +185,7 @@ git push --delete origin BRANCH_NAME
 - Create a new tag to generate a new release of the helm chart using the following commands:
 
 ```bash
-git tag -a 7.0.11 -m "New release" #example
+git tag -a 7.0.12 -m "New release" #example
 git push upstream --tags
 ```
 

--- a/charts/zabbix/Chart.yaml
+++ b/charts/zabbix/Chart.yaml
@@ -1,9 +1,9 @@
 ---
 apiVersion: v2  # Don't change this
 name: zabbix
-version: 7.0.11  # helm chart version
+version: 7.0.12  # helm chart version
 # LTS Zabbix version by default due to stability. See: https://www.zabbix.com/life_cycle_and_release_policy
-appVersion: 7.0.13  # zabbix version
+appVersion: 7.0.16  # zabbix version
 description: Zabbix is a mature and effortless enterprise-class open source monitoring solution for network monitoring and application monitoring of millions of metrics.
 keywords:
   - zabbix

--- a/charts/zabbix/Makefile
+++ b/charts/zabbix/Makefile
@@ -5,7 +5,7 @@
 #---------------------------
 
 URL=https://github.com/zabbix-community/helm-zabbix/
-HELM_IMAGE=alpine/helm:3.18.0
+HELM_IMAGE=alpine/helm:3.18.3
 HELM_DOCS_IMAGE=jnorwood/helm-docs:v1.14.2
 KNOWN_TARGETS=helm
 

--- a/charts/zabbix/README.md
+++ b/charts/zabbix/README.md
@@ -1,6 +1,6 @@
 # Helm chart for Zabbix
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 7.0.11](https://img.shields.io/badge/Version-7.0.11-informational?style=flat-square)  [![Downloads](https://img.shields.io/github/downloads/zabbix-community/helm-zabbix/total?label=Downloads
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 7.0.12](https://img.shields.io/badge/Version-7.0.12-informational?style=flat-square)  [![Downloads](https://img.shields.io/github/downloads/zabbix-community/helm-zabbix/total?label=Downloads
 )](https://somsubhra.github.io/github-release-stats/?username=zabbix-community&repository=helm-zabbix&page=1&per_page=500#) [![Releases ChangeLog](https://img.shields.io/badge/Changelog-8A2BE2
 )](https://github.com/zabbix-community/helm-zabbix/releases)
 
@@ -83,7 +83,7 @@ helm search repo zabbix-community/zabbix -l
 Set the helm chart version you want to use. Example:
 
 ```bash
-export ZABBIX_CHART_VERSION='7.0.11'
+export ZABBIX_CHART_VERSION='7.0.12'
 ```
 
 Export default values of ``zabbix`` chart to ``$HOME/zabbix_values.yaml`` file:
@@ -297,7 +297,7 @@ possible is possible, while still obtaining a good level of security.
 - This helm chart is compatible with non-LTS version of Zabbix, that include important changes and functionalities.
 - But by default this helm chart will install the latest LTS version (example: 7.0.x).
 See more info in [Zabbix Life Cycle & Release Policy](https://www.zabbix.com/life_cycle_and_release_policy) page
-- When you want use a non-LTS version (example: 7.2.x), you have to set this in ``values.yaml`` yourself. This Helm Chart is actively being tested with the current non-LTS major releases, so it will be most probably working without any problem just setting `zabbixImageTag`, for example to the value of `ubuntu-7.2.1` or `alpine-7.2-latest`.
+- When you want use a non-LTS version (example: 7.4.x), you have to set this in ``values.yaml`` yourself. This Helm Chart is actively being tested with the current non-LTS major releases, so it will be most probably working without any problem just setting `zabbixImageTag`, for example to the value of `ubuntu-7.4.0` or `alpine-7.4-latest`.
 
 ## Zabbix Server
 
@@ -414,7 +414,7 @@ The following tables lists the configurable parameters of the chart and their de
 | postgresAccess.user | string | `"zabbix"` | User of database, ignored if existingSecretName is set |
 | postgresql.enabled | bool | `true` | Create a database using Postgresql. Not usable in combination with ``zabbixserver.zabbixServerHA=true`` |
 | postgresql.extraContainers | list | `[]` | Additional containers to start within the postgresql pod |
-| postgresql.extraEnv | list | `[]` | Extra environment variables. A list of additional environment variables. |
+| postgresql.extraEnv | list | `[]` | Extra environment variables. A list of additional environment variables. See: https://www.postgresql.org/docs/16/libpq-envars.html |
 | postgresql.extraInitContainers | list | `[]` | Additional init containers to start within the postgresql pod |
 | postgresql.extraPodAnnotations | object | `{}` | Annotations to add to the pod |
 | postgresql.extraPodLabels | object | `{}` | Labels to add to the pod |
@@ -461,7 +461,7 @@ The following tables lists the configurable parameters of the chart and their de
 | zabbixAgent.extraDaemonSetAnnotations | object | `{}` | Annotations to add to the daemonSet |
 | zabbixAgent.extraDaemonSetLabels | object | `{}` | Labels to add to the daemonSet |
 | zabbixAgent.extraDeploymentLabels | object | `{}` | Labels to add to the deployment |
-| zabbixAgent.extraEnv | list | `[]` | Extra environment variables. A list of additional environment variables. List can be extended with other environment variables listed here: https://github.com/zabbix/zabbix-docker/tree/6.0/Dockerfiles/agent2/alpine#environment-variables. See example: https://github.com/zabbix-community/helm-zabbix/blob/main/charts/zabbix/docs/example/kind/values.yaml |
+| zabbixAgent.extraEnv | list | `[]` | Extra environment variables. A list of additional environment variables. List can be extended with other environment variables listed here: https://github.com/zabbix/zabbix-docker/tree/7.0/Dockerfiles/agent2/alpine#environment-variables. See example: https://github.com/zabbix-community/helm-zabbix/blob/main/charts/zabbix/docs/example/kind/values.yaml |
 | zabbixAgent.extraInitContainers | list | `[]` | Additional init containers to start within the Zabbix Agent pod |
 | zabbixAgent.extraPodAnnotations | object | `{}` | Annotations to add to the pods |
 | zabbixAgent.extraPodLabels | object | `{}` | Labels to add to the pods |
@@ -496,16 +496,46 @@ The following tables lists the configurable parameters of the chart and their de
 | zabbixAgent.startupProbe.tcpSocket.port | string | `"zabbix-agent"` | Port number/alias name of the container |
 | zabbixBrowserMonitoring.customWebDriverURL | string | `""` | Custom WebDriver URL. If set, it overrides the default internal WebDriver service URL. Set zabbixBrowserMonitoring.webdriver.enabled to false when setting this. |
 | zabbixBrowserMonitoring.enabled | bool | `false` | Enable browser pollers |
+| zabbixBrowserMonitoring.extraContainers | list | `[]` | Additional containers to start within the Zabbix WebDriver pod |
+| zabbixBrowserMonitoring.extraDeploymentAnnotations | object | `{}` | Annotations to add to the deployment |
+| zabbixBrowserMonitoring.extraDeploymentLabels | object | `{}` | Labels to add to the deployment |
+| zabbixBrowserMonitoring.extraEnv | list | `[]` | Extra environment variables. A list of additional environment variables. List can be extended with other environment variables listed here: https://www.selenium.dev/documentation/grid/configuration |
+| zabbixBrowserMonitoring.extraInitContainers | list | `[]` | Additional init containers to start within the Zabbix WebDriver pod |
+| zabbixBrowserMonitoring.extraPodAnnotations | object | `{}` | Annotations to add to the pods |
+| zabbixBrowserMonitoring.extraPodLabels | object | `{}` | Labels to add to the pods |
+| zabbixBrowserMonitoring.extraPodSpecs | object | `{}` | Additional specifications to the Zabbix WebDriver pod |
+| zabbixBrowserMonitoring.extraVolumeMounts | list | `[]` | Additional volumeMounts to the Zabbix WebDriver container |
+| zabbixBrowserMonitoring.extraVolumes | list | `[]` | Additional volumes to make available to the Zabbix WebDriver pod |
+| zabbixBrowserMonitoring.livenessProbe | object | `{}` |  |
 | zabbixBrowserMonitoring.nodeSelector | object | `{}` | nodeSelector configurations. Reference: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/ |
 | zabbixBrowserMonitoring.pollers | int | `1` | Number of browser pollers to start |
+| zabbixBrowserMonitoring.readinessProbe | object | `{}` |  |
+| zabbixBrowserMonitoring.securityContext | object | `{}` | Security Context configurations. Reference: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
+| zabbixBrowserMonitoring.service.annotations | object | `{}` | Annotations for the Zabbix WebDriver |
+| zabbixBrowserMonitoring.service.clusterIP | string | `nil` | clusterIP is the IP address of the service and is usually assigned randomly. If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service. |
+| zabbixBrowserMonitoring.service.externalIPs | list | `[]` | externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service. These IPs are not managed by Kubernetes. |
+| zabbixBrowserMonitoring.service.loadBalancerClass | string | `""` | loadBalancerClass is the class of the load balancer implementation this Service belongs to. If specified, the value of this field must be a label-style identifier, with an optional prefix, e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users. This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load balancer implementation is used, today this is typically done through the cloud provider integration, but should apply for any default implementation. If set, it is assumed that a load balancer implementation is watching for Services with a matching class. Any default load balancer implementation (e.g. cloud providers) should ignore Services that set this field. This field can only be set when creating or updating a Service to type 'LoadBalancer'. Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type. |
+| zabbixBrowserMonitoring.service.loadBalancerIP | string | `""` | Only applies to Service Type: LoadBalancer. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature. |
+| zabbixBrowserMonitoring.service.loadBalancerSourceRanges | list | `[]` | If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature. |
+| zabbixBrowserMonitoring.service.nodePort1 | int | `31444` | NodePort port 1 to allocate on each node (only if service.type = NodePort or Loadbalancer) |
+| zabbixBrowserMonitoring.service.nodePort2 | int | `31900` | NodePort port 2 to allocate on each node (only if service.type = NodePort or Loadbalancer) |
+| zabbixBrowserMonitoring.service.port1 | int | `4444` | Port 1 of service in Kubernetes cluster |
+| zabbixBrowserMonitoring.service.port2 | int | `7900` | Port 2 of service in Kubernetes cluster |
+| zabbixBrowserMonitoring.service.sessionAffinity | string | `"None"` | Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies |
+| zabbixBrowserMonitoring.service.type | string | `"ClusterIP"` | Type of service to expose the application. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. More details: https://kubernetes.io/docs/concepts/services-networking/service/ |
+| zabbixBrowserMonitoring.startupProbe | object | `{}` | The kubelet uses startup probes to know when a container application has started.  Reference: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/ |
 | zabbixBrowserMonitoring.webdriver.enabled | bool | `true` | Enable webdriver |
 | zabbixBrowserMonitoring.webdriver.image.pullPolicy | string | `"IfNotPresent"` | Pull policy of Docker image |
 | zabbixBrowserMonitoring.webdriver.image.pullSecrets | list | `[]` | List of dockerconfig secrets names to use when pulling images |
 | zabbixBrowserMonitoring.webdriver.image.repository | string | `"selenium/standalone-chrome"` | WebDriver container image |
-| zabbixBrowserMonitoring.webdriver.image.tag | string | `"127.0-chromedriver-127.0-grid-4.23.0-20240727"` | WebDriver container image tag, See https://hub.docker.com/r/selenium/standalone-chrome/tags |
+| zabbixBrowserMonitoring.webdriver.image.tag | string | `"124.0-chromedriver-124.0-grid-4.33.0-20250606"` | WebDriver container image tag, See https://hub.docker.com/r/selenium/standalone-chrome/tags |
 | zabbixBrowserMonitoring.webdriver.name | string | `"chrome"` | WebDriver container name |
-| zabbixBrowserMonitoring.webdriver.port | int | `4444` | WebDriver container port |
-| zabbixImageTag | string | `"ubuntu-7.0.13"` | Zabbix components (server, agent, web frontend, ...) image tag to use. This helm chart is compatible with non-LTS version of Zabbix, that include important changes and functionalities. But by default this helm chart will install the latest LTS version (example: 7.0.x). See more info in [Zabbix Life Cycle & Release Policy](https://www.zabbix.com/life_cycle_and_release_policy) page When you want use a non-LTS version (example: 7.2.x), you have to set this yourself. You can change version here or overwrite in each component (example: zabbixserver.image.tag, etc). |
+| zabbixBrowserMonitoring.webdriver.podAntiAffinity | bool | `true` | set permissive podAntiAffinity to spread replicas over cluster nodes if replicaCount>1 |
+| zabbixBrowserMonitoring.webdriver.port1 | int | `4444` | WebDriver container port 1 |
+| zabbixBrowserMonitoring.webdriver.port2 | int | `7900` | WebDriver container port 2 |
+| zabbixBrowserMonitoring.webdriver.replicaCount | int | `1` | Number of replicas of ``zabbixWebDriver`` module |
+| zabbixBrowserMonitoring.webdriver.resources | object | `{}` | Requests and limits of pod resources. See: [https://kubernetes.io/docs/concepts/configuration/manage-resources-containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers) |
+| zabbixImageTag | string | `"ubuntu-7.0.16"` | Zabbix components (server, agent, web frontend, ...) image tag to use. This helm chart is compatible with non-LTS version of Zabbix, that include important changes and functionalities. But by default this helm chart will install the latest LTS version (example: 7.0.x). See more info in [Zabbix Life Cycle & Release Policy](https://www.zabbix.com/life_cycle_and_release_policy) page When you want use a non-LTS version (example: 7.4.x), you have to set this yourself. You can change version here or overwrite in each component (example: zabbixserver.image.tag, etc). |
 | zabbixJavaGateway.ZABBIX_OPTIONS | string | `""` | Additional arguments for Zabbix Java Gateway. Useful to enable additional libraries and features. |
 | zabbixJavaGateway.ZBX_DEBUGLEVEL | int | `3` | The variable is used to specify debug level, from 0 to 5 |
 | zabbixJavaGateway.ZBX_JAVAGATEWAY | string | `"zabbix-java-gateway"` |  |
@@ -516,7 +546,7 @@ The following tables lists the configurable parameters of the chart and their de
 | zabbixJavaGateway.extraContainers | list | `[]` | Additional containers to start within the Zabbix Java Gateway pod |
 | zabbixJavaGateway.extraDeploymentAnnotations | object | `{}` | Annotations to add to the deployment |
 | zabbixJavaGateway.extraDeploymentLabels | object | `{}` | Labels to add to the deployment |
-| zabbixJavaGateway.extraEnv | list | `[]` | Extra environment variables. A list of additional environment variables. List can be extended with other environment variables listed here: https://github.com/zabbix/zabbix-docker/tree/6.0/Dockerfiles/agent2/alpine#environment-variables. See example: https://github.com/zabbix-community/helm-zabbix/blob/main/charts/zabbix/docs/example/kind/values.yaml |
+| zabbixJavaGateway.extraEnv | list | `[]` | Extra environment variables. A list of additional environment variables. List can be extended with other environment variables listed here: https://github.com/zabbix/zabbix-docker/tree/7.0/Dockerfiles/java-gateway/alpine#environment-variables. See example: https://github.com/zabbix-community/helm-zabbix/blob/main/charts/zabbix/docs/example/kind/values.yaml |
 | zabbixJavaGateway.extraInitContainers | list | `[]` | Additional init containers to start within the Zabbix Java Gateway pod |
 | zabbixJavaGateway.extraPodAnnotations | object | `{}` | Annotations to add to the pod |
 | zabbixJavaGateway.extraPodLabels | object | `{}` | Labels to add to the pod |
@@ -557,7 +587,7 @@ The following tables lists the configurable parameters of the chart and their de
 | zabbixProxy.ZBX_VMWARECACHESIZE | string | `"128M"` | Cache size |
 | zabbixProxy.enabled | bool | `false` | Enables use of **Zabbix Proxy** |
 | zabbixProxy.extraContainers | list | `[]` | Additional containers to start within the Zabbix Proxy pod |
-| zabbixProxy.extraEnv | list | `[]` | Extra environment variables. A list of additional environment variables. List can be extended with other environment variables listed here: https://github.com/zabbix/zabbix-docker/tree/6.0/Dockerfiles/proxy-sqlite3/alpine#environment-variables. See example: https://github.com/zabbix-community/helm-zabbix/blob/main/charts/zabbix/docs/example/kind/values.yaml |
+| zabbixProxy.extraEnv | list | `[]` | Extra environment variables. A list of additional environment variables. List can be extended with other environment variables listed here: https://github.com/zabbix/zabbix-docker/tree/7.0/Dockerfiles/proxy-sqlite3/alpine#environment-variables. See example: https://github.com/zabbix-community/helm-zabbix/blob/main/charts/zabbix/docs/example/kind/values.yaml |
 | zabbixProxy.extraInitContainers | list | `[]` | Additional init containers to start within the Zabbix Proxy pod |
 | zabbixProxy.extraPodAnnotations | object | `{}` | Annotations to add to the pod |
 | zabbixProxy.extraPodLabels | object | `{}` | Labels to add to the pod |
@@ -593,7 +623,7 @@ The following tables lists the configurable parameters of the chart and their de
 | zabbixServer.extraContainers | list | `[]` | Additional containers to start within the Zabbix Server pod |
 | zabbixServer.extraDeploymentAnnotations | object | `{}` | Annotations to add to the deployment |
 | zabbixServer.extraDeploymentLabels | object | `{}` | Labels to add to the deployment |
-| zabbixServer.extraEnv | list | `[]` | Extra environment variables. A list of additional environment variables. List can be extended with other environment variables listed here: https://github.com/zabbix/zabbix-docker/tree/6.0/Dockerfiles/server-pgsql/alpine#environment-variables. See example: https://github.com/zabbix-community/helm-zabbix/blob/main/charts/zabbix/docs/example/kind/values.yaml |
+| zabbixServer.extraEnv | list | `[]` | Extra environment variables. A list of additional environment variables. List can be extended with other environment variables listed here: https://github.com/zabbix/zabbix-docker/tree/7.0/Dockerfiles/server-pgsql/alpine#environment-variables. See example: https://github.com/zabbix-community/helm-zabbix/blob/main/charts/zabbix/docs/example/kind/values.yaml |
 | zabbixServer.extraInitContainers | list | `[]` | Additional init containers to start within the Zabbix Server pod |
 | zabbixServer.extraPodAnnotations | object | `{}` | Annotations to add to the pods |
 | zabbixServer.extraPodLabels | object | `{}` | Labels to add to the pods |
@@ -672,7 +702,7 @@ The following tables lists the configurable parameters of the chart and their de
 | zabbixWeb.extraContainers | list | `[]` | Additional containers to start within the Zabbix Web pod |
 | zabbixWeb.extraDeploymentAnnotations | object | `{}` | Annotations to add to the deployment |
 | zabbixWeb.extraDeploymentLabels | object | `{}` | Labels to add to the deployment |
-| zabbixWeb.extraEnv | list | `[]` | Extra environment variables. A list of additional environment variables. List can be extended with other environment variables listed here: https://github.com/zabbix/zabbix-docker/tree/6.0/Dockerfiles/web-apache-pgsql/alpine#environment-variables. See example: https://github.com/zabbix-community/helm-zabbix/blob/main/charts/zabbix/docs/example/kind/values.yaml |
+| zabbixWeb.extraEnv | list | `[]` | Extra environment variables. A list of additional environment variables. List can be extended with other environment variables listed here: https://github.com/zabbix/zabbix-docker/tree/7.0/Dockerfiles/web-apache-pgsql/alpine#environment-variables. See example: https://github.com/zabbix-community/helm-zabbix/blob/main/charts/zabbix/docs/example/kind/values.yaml |
 | zabbixWeb.extraInitContainers | list | `[]` | Additional init containers to start within the Zabbix Web pod |
 | zabbixWeb.extraPodAnnotations | object | `{}` | Annotations to add to the pods |
 | zabbixWeb.extraPodLabels | object | `{}` | Labels to add to the pods |
@@ -722,7 +752,7 @@ The following tables lists the configurable parameters of the chart and their de
 | zabbixWebService.extraContainers | list | `[]` | Additional containers to start within the Zabbix Web Service pod |
 | zabbixWebService.extraDeploymentAnnotations | object | `{}` | Annotations to add to the deployment |
 | zabbixWebService.extraDeploymentLabels | object | `{}` | Labels to add to the deployment |
-| zabbixWebService.extraEnv | list | `[]` | Extra environment variables. A list of additional environment variables. List can be extended with other environment variables listed here: https://github.com/zabbix/zabbix-docker/tree/6.0/Dockerfiles/web-service/alpine#environment-variables. See example: https://github.com/zabbix-community/helm-zabbix/blob/main/charts/zabbix/docs/example/kind/values.yaml |
+| zabbixWebService.extraEnv | list | `[]` | Extra environment variables. A list of additional environment variables. List can be extended with other environment variables listed here: https://github.com/zabbix/zabbix-docker/tree/7.0/Dockerfiles/web-service/alpine#environment-variables. See example: https://github.com/zabbix-community/helm-zabbix/blob/main/charts/zabbix/docs/example/kind/values.yaml |
 | zabbixWebService.extraInitContainers | list | `[]` | Additional init containers to start within the Zabbix Web Service pod |
 | zabbixWebService.extraPodAnnotations | object | `{}` | Annotations to add to the pods |
 | zabbixWebService.extraPodLabels | object | `{}` | Labels to add to the pods |

--- a/charts/zabbix/README.md
+++ b/charts/zabbix/README.md
@@ -743,7 +743,7 @@ The following tables lists the configurable parameters of the chart and their de
 | zabbixWeb.service.loadBalancerIP | string | `""` | Only applies to Service Type: LoadBalancer. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature. |
 | zabbixWeb.service.loadBalancerSourceRanges | list | `[]` | If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature. |
 | zabbixWeb.service.nodePort | int | `31080` | NodePort port to allocate on each node (only if service.type = NodePort or Loadbalancer) |
-| zabbixWeb.service.port | int | `80` |  |
+| zabbixWeb.service.port | int | `80` | Port of service in Kubernetes cluster |
 | zabbixWeb.service.sessionAffinity | string | `"None"` | Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies |
 | zabbixWeb.service.type | string | `"ClusterIP"` | Type of service to expose the application. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. More details: https://kubernetes.io/docs/concepts/services-networking/service/ |
 | zabbixWeb.startupProbe | object | `{}` | The kubelet uses startup probes to know when a container application has started.  Reference: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/ |

--- a/charts/zabbix/README.md.gotmpl
+++ b/charts/zabbix/README.md.gotmpl
@@ -1,6 +1,6 @@
 # Helm chart for Zabbix
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 7.0.11](https://img.shields.io/badge/Version-7.0.11-informational?style=flat-square)  [![Downloads](https://img.shields.io/github/downloads/zabbix-community/helm-zabbix/total?label=Downloads
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Version: 7.0.12](https://img.shields.io/badge/Version-7.0.12-informational?style=flat-square)  [![Downloads](https://img.shields.io/github/downloads/zabbix-community/helm-zabbix/total?label=Downloads
 )](https://somsubhra.github.io/github-release-stats/?username=zabbix-community&repository=helm-zabbix&page=1&per_page=500#) [![Releases ChangeLog](https://img.shields.io/badge/Changelog-8A2BE2
 )](https://github.com/zabbix-community/helm-zabbix/releases)
 
@@ -298,7 +298,7 @@ possible is possible, while still obtaining a good level of security.
 - This helm chart is compatible with non-LTS version of Zabbix, that include important changes and functionalities. 
 - But by default this helm chart will install the latest LTS version (example: 7.0.x). 
 See more info in [Zabbix Life Cycle & Release Policy](https://www.zabbix.com/life_cycle_and_release_policy) page
-- When you want use a non-LTS version (example: 7.2.x), you have to set this in ``values.yaml`` yourself. This Helm Chart is actively being tested with the current non-LTS major releases, so it will be most probably working without any problem just setting `zabbixImageTag`, for example to the value of `ubuntu-7.2.1` or `alpine-7.2-latest`.
+- When you want use a non-LTS version (example: 7.4.x), you have to set this in ``values.yaml`` yourself. This Helm Chart is actively being tested with the current non-LTS major releases, so it will be most probably working without any problem just setting `zabbixImageTag`, for example to the value of `ubuntu-7.4.0` or `alpine-7.4-latest`.
 
 ## Zabbix Server
 

--- a/charts/zabbix/artifacthub-pkg.yml
+++ b/charts/zabbix/artifacthub-pkg.yml
@@ -5,13 +5,13 @@
 # https://github.com/kedacore/external-scalers/blob/main/artifacthub/azure-cosmos-db/0.1.0/artifacthub-pkg.yml
 # https://artifacthub.io/packages/keda-scaler/keda-official-external-scalers/external-scaler-azure-cosmos-db?modal=install
 
-version: 7.0.11  # helm chart version
+version: 7.0.12  # helm chart version
 # LTS Zabbix version by default due to stability. See: https://www.zabbix.com/life_cycle_and_release_policy
-appVersion: 7.0.13  # zabbix version
+appVersion: 7.0.16  # zabbix version
 name: zabbix
 category: monitoring, networking, metrics
 displayName: Zabbix - The Enterprise-Class Open Source Network Monitoring Solution
-createdAt: 2025-06-11T06:44:57Z # Command Linux: date +%Y-%m-%dT%TZ
+createdAt: 2025-07-01T09:44:43Z # Command Linux: date +%Y-%m-%dT%TZ
 description: Zabbix is a mature and effortless enterprise-class open source monitoring solution for network monitoring and application monitoring of millions of metrics.
 logoURL: https://assets.zabbix.com/img/logo/zabbix_logo_500x131.png
 license: Apache-2.0
@@ -53,7 +53,7 @@ install: |
   Set the helm chart version you want to use. Example:
 
   ```bash
-  export ZABBIX_CHART_VERSION='7.0.11'
+  export ZABBIX_CHART_VERSION='7.0.12'
   ```
 
   Export default values of ``zabbix`` chart to ``$HOME/zabbix_values.yaml`` file:

--- a/charts/zabbix/docs/example/kind/values.yaml
+++ b/charts/zabbix/docs/example/kind/values.yaml
@@ -5,7 +5,7 @@
 #    mylabel: "my-value"
 
 # Custom values for zabbix.
-zabbixImageTag: alpine-7.2.7
+zabbixImageTag: alpine-7.4.0
 
 zabbixServer:
   enabled: true
@@ -18,10 +18,10 @@ zabbixServer:
       # Postgresql Docker image name: chose one of "postgres" or "timescale/timescaledb"
       repository: postgres
       #repository: timescale/timescaledb
-      # -- Tag of Docker image of Postgresql server, choice "17" for postgres "2.17.2-pg16" for timescaledb
-      # (Zabbix supports TimescaleDB. More info: https://www.zabbix.com/documentation/7.2/en/manual/installation/requirements)
+      # -- Tag of Docker image of Postgresql server, choice "17" for postgres "2.19.3-pg17" for timescaledb
+      # (Zabbix supports TimescaleDB. More info: https://www.zabbix.com/documentation/7.4/en/manual/installation/requirements)
       tag: 17
-      #tag: 2.17.2-pg16
+      #tag: 2.19.3-pg17
   service:
     type: NodePort
     port: 10051
@@ -178,4 +178,7 @@ zabbixWeb:
 #          - linux
 
 #zabbixJavaGateway:
+#  enabled: true
+
+#zabbixBrowserMonitoring:
 #  enabled: true

--- a/charts/zabbix/templates/deployment-webdriver.yaml
+++ b/charts/zabbix/templates/deployment-webdriver.yaml
@@ -7,33 +7,109 @@ metadata:
   labels:
     {{- include "zabbix.labels" . | nindent 4 }}
     app.kubernetes.io/component: webdriver
+    {{- if .Values.zabbixBrowserMonitoring.extraDeploymentLabels }}
+    {{- toYaml .Values.zabbixBrowserMonitoring.extraDeploymentLabels | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- range $key,$value := .Values.zabbixBrowserMonitoring.extraDeploymentAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.zabbixBrowserMonitoring.webdriver.replicaCount }}
   selector:
     matchLabels:
       {{- include "zabbix.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: webdriver
   template:
     metadata:
+      annotations:
+        {{- range $key,$value := .Values.zabbixBrowserMonitoring.extraPodAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
       labels:
         {{- include "zabbix.labels" . | nindent 8 }}
         app.kubernetes.io/component: webdriver
+        {{- if .Values.zabbixBrowserMonitoring.extraPodLabels }}
+        {{- toYaml .Values.zabbixBrowserMonitoring.extraPodLabels | nindent 8 }}
+        {{- end }}
     spec:
+      serviceAccountName: {{ template "zabbix.serviceAccountName" . }}
+      {{- with .Values.zabbixBrowserMonitoring.extraPodSpecs }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+      {{- with .Values.zabbixBrowserMonitoring.extraInitContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.zabbixBrowserMonitoring.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if gt (len .Values.affinity) 0 }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+      {{- else if .Values.zabbixBrowserMonitoring.webdriver.podAntiAffinity }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/instance: {{ .Release.Name }}-{{ .Values.zabbixBrowserMonitoring.webdriver.name }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Values.zabbixBrowserMonitoring.webdriver.name }}
+        resources:
+          {{- toYaml .Values.zabbixBrowserMonitoring.webdriver.resources | nindent 10 }}
+        securityContext:
+          {{- toYaml .Values.zabbixBrowserMonitoring.securityContext | nindent 10 }}
         imagePullPolicy: {{ .Values.zabbixBrowserMonitoring.webdriver.image.pullPolicy }}
         image: {{ .Values.zabbixBrowserMonitoring.webdriver.image.repository }}:{{ .Values.zabbixBrowserMonitoring.webdriver.image.tag }}
+        env:
+          {{- with .Values.zabbixBrowserMonitoring.extraEnv }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
         ports:
-        - containerPort: {{ .Values.zabbixBrowserMonitoring.webdriver.port }}
+        - containerPort: {{ .Values.zabbixBrowserMonitoring.webdriver.port1 }}
+          name: webdriver1
+          protocol: TCP
+        - containerPort: {{ .Values.zabbixBrowserMonitoring.webdriver.port2 }}
+          name: webdriver2
+          protocol: TCP
+        volumeMounts:
+        {{- with .Values.zabbixBrowserMonitoring.extraVolumeMounts }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.zabbixBrowserMonitoring.livenessProbe }}
+        livenessProbe:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.zabbixBrowserMonitoring.readinessProbe }}
+        readinessProbe:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.zabbixBrowserMonitoring.startupProbe }}
+        startupProbe:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- with .Values.zabbixBrowserMonitoring.extraContainers }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
       imagePullSecrets:
       {{- range .Values.zabbixBrowserMonitoring.webdriver.image.pullSecrets }}
         - name: {{ . | quote }}
       {{- end }}
       {{- with .Values.global.imagePullSecrets }}
       {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+      {{- with .Values.zabbixBrowserMonitoring.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/zabbix/templates/deployment-zabbix-server.yaml
+++ b/charts/zabbix/templates/deployment-zabbix-server.yaml
@@ -156,7 +156,7 @@ spec:
               value: {{ .Values.zabbixBrowserMonitoring.customWebDriverURL | quote }}
             {{- else }}
             - name: ZBX_WEBDRIVERURL
-              value: http://{{ template "zabbix.fullname" . }}-{{ .Values.zabbixBrowserMonitoring.webdriver.name }}:{{ .Values.zabbixBrowserMonitoring.webdriver.port }}
+              value: http://{{ template "zabbix.fullname" . }}-{{ .Values.zabbixBrowserMonitoring.webdriver.name }}:{{ .Values.zabbixBrowserMonitoring.service.port1 }}
             {{- end }}
           {{- with .Values.zabbixServer.extraVolumeMounts }}
           volumeMounts:

--- a/charts/zabbix/templates/service.yaml
+++ b/charts/zabbix/templates/service.yaml
@@ -344,13 +344,51 @@ metadata:
   labels:
     {{- include "zabbix.labels" . | nindent 4 }}
     app.kubernetes.io/component: webdriver
+  {{- if .Values.zabbixBrowserMonitoring.service.annotations }}
+  annotations:
+    {{- range $key,$value := .Values.zabbixBrowserMonitoring.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
 spec:
+  type: {{ .Values.zabbixBrowserMonitoring.service.type }}
+  {{- if and .Values.zabbixBrowserMonitoring.service.externalTrafficPolicy (or (eq .Values.zabbixBrowserMonitoring.service.type "NodePort") (eq .Values.zabbixBrowserMonitoring.service.type "LoadBalancer" )) }}
+  externalTrafficPolicy: {{ .Values.zabbixBrowserMonitoring.service.externalTrafficPolicy }}
+  {{- end }}
+  {{- if and .Values.zabbixBrowserMonitoring.service.externalIPs (eq .Values.zabbixBrowserMonitoring.service.type "LoadBalancer") }}
+  externalIPs: {{ .Values.zabbixBrowserMonitoring.service.externalIPs | toYaml | nindent 6 }}
+  {{- end }}
+  {{- if and .Values.zabbixBrowserMonitoring.service.loadBalancerIP (eq .Values.zabbixBrowserMonitoring.service.type "LoadBalancer") }}
+  loadBalancerIP: {{ .Values.zabbixBrowserMonitoring.service.loadBalancerIP }}
+  {{- end }}
+  {{- if and .Values.zabbixBrowserMonitoring.service.clusterIP (eq .Values.zabbixBrowserMonitoring.service.type "ClusterIP") }}
+  clusterIP: {{ .Values.zabbixBrowserMonitoring.service.clusterIP }}
+  {{- end }}
+  {{- if .Values.zabbixBrowserMonitoring.service.sessionAffinity }}
+  sessionAffinity: {{ .Values.zabbixBrowserMonitoring.service.sessionAffinity }}
+  {{- end }}
+  {{- if and (eq .Values.zabbixBrowserMonitoring.service.type "LoadBalancer") (not (empty .Values.zabbixBrowserMonitoring.service.loadBalancerSourceRanges)) }}
+  loadBalancerSourceRanges: {{- toYaml .Values.zabbixBrowserMonitoring.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
+  {{- if and (eq .Values.zabbixBrowserMonitoring.service.type "LoadBalancer") .Values.zabbixBrowserMonitoring.service.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.zabbixBrowserMonitoring.service.loadBalancerClass }}
+  {{- end }}
   ports:
-    - port: {{ .Values.zabbixBrowserMonitoring.webdriver.port }}
-      targetPort: {{ .Values.zabbixBrowserMonitoring.webdriver.port }}
+    - port: {{ .Values.zabbixBrowserMonitoring.service.port1 }}
+      name: zabbix-webdriver1
+      targetPort: {{ .Values.zabbixBrowserMonitoring.webdriver.port1 }}
       protocol: TCP
+      {{- if and (or (eq .Values.zabbixBrowserMonitoring.service.type "NodePort") (eq .Values.zabbixBrowserMonitoring.service.type "LoadBalancer" )) (not (empty .Values.zabbixBrowserMonitoring.service.nodePort2)) }}
+      nodePort: {{ .Values.zabbixBrowserMonitoring.service.nodePort1 }}
+      {{- end }}
+    - port: {{ .Values.zabbixBrowserMonitoring.service.port2 }}
+      name: zabbix-webdriver2
+      targetPort: {{ .Values.zabbixBrowserMonitoring.webdriver.port2 }}
+      protocol: TCP
+      {{- if and (or (eq .Values.zabbixBrowserMonitoring.service.type "NodePort") (eq .Values.zabbixBrowserMonitoring.service.type "LoadBalancer" )) (not (empty .Values.zabbixBrowserMonitoring.service.nodePort2)) }}
+      nodePort: {{ .Values.zabbixBrowserMonitoring.service.nodePort2 }}
+      {{- end }}
   selector:
     {{- include "zabbix.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: webdriver
-  type: ClusterIP
 {{- end }}

--- a/charts/zabbix/values.yaml
+++ b/charts/zabbix/values.yaml
@@ -635,7 +635,8 @@ zabbixWeb:
     # -- Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity.
     # Must be ClientIP or None. Defaults to None. More info:
     # https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
-    sessionAffinity: None  # -- Port of service in Kubernetes cluster
+    sessionAffinity: None
+    # -- Port of service in Kubernetes cluster
     port: 80
     # -- NodePort port to allocate on each node (only if service.type = NodePort or Loadbalancer)
     nodePort: 31080

--- a/charts/zabbix/values.yaml
+++ b/charts/zabbix/values.yaml
@@ -18,9 +18,9 @@ global:
 # This helm chart is compatible with non-LTS version of Zabbix, that include important changes and functionalities.
 # But by default this helm chart will install the latest LTS version (example: 7.0.x).
 # See more info in [Zabbix Life Cycle & Release Policy](https://www.zabbix.com/life_cycle_and_release_policy) page
-# When you want use a non-LTS version (example: 7.2.x), you have to set this yourself. You can change version
+# When you want use a non-LTS version (example: 7.4.x), you have to set this yourself. You can change version
 # here or overwrite in each component (example: zabbixserver.image.tag, etc).
-zabbixImageTag: ubuntu-7.0.13
+zabbixImageTag: ubuntu-7.0.16
 
 # **Zabbix Postgresql access / credentials** configurations
 # with this dict, you can set unified PostgreSQL access credentials, IP and so on for both Zabbix Server and Zabbix web frontend
@@ -234,7 +234,7 @@ zabbixServer:
     # -- Annotations for the zabbix-server service
     annotations: {}
     # metallb.universe.tf/address-pool: production-public-ips
-  # -- Extra environment variables. A list of additional environment variables. List can be extended with other environment variables listed here: https://github.com/zabbix/zabbix-docker/tree/6.0/Dockerfiles/server-pgsql/alpine#environment-variables. See example: https://github.com/zabbix-community/helm-zabbix/blob/main/charts/zabbix/docs/example/kind/values.yaml
+  # -- Extra environment variables. A list of additional environment variables. List can be extended with other environment variables listed here: https://github.com/zabbix/zabbix-docker/tree/7.0/Dockerfiles/server-pgsql/alpine#environment-variables. See example: https://github.com/zabbix-community/helm-zabbix/blob/main/charts/zabbix/docs/example/kind/values.yaml
   extraEnv: []
   # - name: ENABLE_TIMESCALEDB
   #   value: "true"
@@ -309,7 +309,7 @@ postgresql:
   # -- Extra Postgresql runtime parameters ("-c" options)
   extraRuntimeParameters:
     max_connections: 100
-  # -- Extra environment variables. A list of additional environment variables.
+  # -- Extra environment variables. A list of additional environment variables. See: https://www.postgresql.org/docs/16/libpq-envars.html
   extraEnv: []
   # -- Annotations to add to the statefulset
   extraStatefulSetAnnotations: {}
@@ -414,7 +414,7 @@ zabbixProxy:
     # -- Annotations for the zabbix-proxy service
     annotations: {}
     # metallb.universe.tf/address-pool: production-public-ips
-  # -- Extra environment variables. A list of additional environment variables. List can be extended with other environment variables listed here: https://github.com/zabbix/zabbix-docker/tree/6.0/Dockerfiles/proxy-sqlite3/alpine#environment-variables. See example: https://github.com/zabbix-community/helm-zabbix/blob/main/charts/zabbix/docs/example/kind/values.yaml
+  # -- Extra environment variables. A list of additional environment variables. List can be extended with other environment variables listed here: https://github.com/zabbix/zabbix-docker/tree/7.0/Dockerfiles/proxy-sqlite3/alpine#environment-variables. See example: https://github.com/zabbix-community/helm-zabbix/blob/main/charts/zabbix/docs/example/kind/values.yaml
   extraEnv: []
   # -- Annotations to add to the statefulset
   extraStatefulSetAnnotations: {}
@@ -530,7 +530,7 @@ zabbixAgent:
   hostNetwork: true
   # -- If true, agent pods mounts host / at /host/root
   hostRootFsMount: true
-  # -- Extra environment variables. A list of additional environment variables. List can be extended with other environment variables listed here: https://github.com/zabbix/zabbix-docker/tree/6.0/Dockerfiles/agent2/alpine#environment-variables. See example: https://github.com/zabbix-community/helm-zabbix/blob/main/charts/zabbix/docs/example/kind/values.yaml
+  # -- Extra environment variables. A list of additional environment variables. List can be extended with other environment variables listed here: https://github.com/zabbix/zabbix-docker/tree/7.0/Dockerfiles/agent2/alpine#environment-variables. See example: https://github.com/zabbix-community/helm-zabbix/blob/main/charts/zabbix/docs/example/kind/values.yaml
   extraEnv: []
   # -- Additional volumeMounts to the zabbix Agent container
   extraVolumeMounts: []
@@ -642,7 +642,7 @@ zabbixWeb:
     # -- Annotations for the Zabbix Web
     annotations: {}
     # metallb.universe.tf/address-pool: production-public-ips
-  # -- Extra environment variables. A list of additional environment variables. List can be extended with other environment variables listed here: https://github.com/zabbix/zabbix-docker/tree/6.0/Dockerfiles/web-apache-pgsql/alpine#environment-variables. See example: https://github.com/zabbix-community/helm-zabbix/blob/main/charts/zabbix/docs/example/kind/values.yaml
+  # -- Extra environment variables. A list of additional environment variables. List can be extended with other environment variables listed here: https://github.com/zabbix/zabbix-docker/tree/7.0/Dockerfiles/web-apache-pgsql/alpine#environment-variables. See example: https://github.com/zabbix-community/helm-zabbix/blob/main/charts/zabbix/docs/example/kind/values.yaml
   extraEnv: []
   #  - name: ZBX_SSO_SETTINGS
   #    value: '{"baseurl": "https://zabbix.example.com"}'
@@ -736,7 +736,7 @@ zabbixWebService:
     # -- Annotations for the Zabbix Web Service
     annotations: {}
     # metallb.universe.tf/address-pool: production-public-ips
-  # -- Extra environment variables. A list of additional environment variables. List can be extended with other environment variables listed here: https://github.com/zabbix/zabbix-docker/tree/6.0/Dockerfiles/web-service/alpine#environment-variables. See example: https://github.com/zabbix-community/helm-zabbix/blob/main/charts/zabbix/docs/example/kind/values.yaml
+  # -- Extra environment variables. A list of additional environment variables. List can be extended with other environment variables listed here: https://github.com/zabbix/zabbix-docker/tree/7.0/Dockerfiles/web-service/alpine#environment-variables. See example: https://github.com/zabbix-community/helm-zabbix/blob/main/charts/zabbix/docs/example/kind/values.yaml
   extraEnv: []
   # -- Annotations to add to the deployment
   extraDeploymentAnnotations: {}
@@ -838,7 +838,7 @@ zabbixJavaGateway:
     # -- Annotations for the zabbix-java-gateway service
     annotations: {}
     # metallb.universe.tf/address-pool: production-public-ips
-  # -- Extra environment variables. A list of additional environment variables. List can be extended with other environment variables listed here: https://github.com/zabbix/zabbix-docker/tree/6.0/Dockerfiles/agent2/alpine#environment-variables. See example: https://github.com/zabbix-community/helm-zabbix/blob/main/charts/zabbix/docs/example/kind/values.yaml
+  # -- Extra environment variables. A list of additional environment variables. List can be extended with other environment variables listed here: https://github.com/zabbix/zabbix-docker/tree/7.0/Dockerfiles/java-gateway/alpine#environment-variables. See example: https://github.com/zabbix-community/helm-zabbix/blob/main/charts/zabbix/docs/example/kind/values.yaml
   extraEnv: []
   # -- Additional volumeMounts to the Zabbix Java Gateway container
   extraVolumeMounts: []
@@ -890,32 +890,106 @@ zabbixJavaGateway:
 zabbixBrowserMonitoring:
   # -- Enable browser pollers
   enabled: false
-
   # -- Number of browser pollers to start
   pollers: 1
-
   webdriver:
     # -- Enable webdriver
     enabled: true
-
     # -- WebDriver container name
     name: chrome
-
+    # -- Number of replicas of ``zabbixWebDriver`` module
+    replicaCount: 1
+    # -- set permissive podAntiAffinity to spread replicas over cluster nodes if replicaCount>1
+    podAntiAffinity: true
+    # -- Requests and limits of pod resources. See: [https://kubernetes.io/docs/concepts/configuration/manage-resources-containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers)
+    resources: {}
     image:
       # -- WebDriver container image
       repository: selenium/standalone-chrome
       # -- WebDriver container image tag, See https://hub.docker.com/r/selenium/standalone-chrome/tags
-      tag: 127.0-chromedriver-127.0-grid-4.23.0-20240727
+      tag: 124.0-chromedriver-124.0-grid-4.33.0-20250606
       # -- Pull policy of Docker image
       pullPolicy: IfNotPresent
       # -- List of dockerconfig secrets names to use when pulling images
       pullSecrets: []
-
-    # -- WebDriver container port
-    port: 4444
-
+    # -- WebDriver container port 1
+    port1: 4444
+    # -- WebDriver container port 2
+    port2: 7900
   # -- Custom WebDriver URL. If set, it overrides the default internal WebDriver service URL. Set zabbixBrowserMonitoring.webdriver.enabled to false when setting this.
   customWebDriverURL: ""
+  service:
+    # -- Type of service to expose the application. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer.
+    # More details: https://kubernetes.io/docs/concepts/services-networking/service/
+    type: ClusterIP
+    # -- clusterIP is the IP address of the service and is usually assigned randomly.
+    # If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service.
+    clusterIP:
+    # -- externalTrafficPolicy describes how nodes distribute service traffic they receive on one of the Service's "externally-facing" addresses
+    # (NodePorts, ExternalIPs, and LoadBalancer IPs). "Local" to preserve sender's IP address. Please note that this might not work on multi-node clusters,
+    # depending on your network settings.
+    # externalTrafficPolicy: Local
+    # -- externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.
+    # These IPs are not managed by Kubernetes.
+    externalIPs: []
+    # -- Only applies to Service Type: LoadBalancer. This feature depends on whether the underlying cloud-provider supports specifying
+    # the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature.
+    loadBalancerIP: ""
+    # -- If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer
+    # will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature.
+    loadBalancerSourceRanges: []
+    # -- loadBalancerClass is the class of the load balancer implementation this Service belongs to.
+    # If specified, the value of this field must be a label-style identifier, with an optional prefix, e.g. "internal-vip" or
+    # "example.com/internal-vip". Unprefixed names are reserved for end-users. This field can only be set when the Service type is 'LoadBalancer'.
+    # If not set, the default load balancer implementation is used, today this is typically done through the cloud provider integration,
+    # but should apply for any default implementation. If set, it is assumed that a load balancer implementation is watching for Services
+    # with a matching class. Any default load balancer implementation (e.g. cloud providers) should ignore Services that set this field.
+    # This field can only be set when creating or updating a Service to type 'LoadBalancer'. Once set, it can not be changed.
+    # This field will be wiped when a service is updated to a non 'LoadBalancer' type.
+    loadBalancerClass: ""
+    # -- Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity.
+    # Must be ClientIP or None. Defaults to None. More info:
+    # https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+    sessionAffinity: None  
+    # -- Port 1 of service in Kubernetes cluster
+    port1: 4444
+    # -- Port 2 of service in Kubernetes cluster
+    port2: 7900
+    # -- NodePort port 1 to allocate on each node (only if service.type = NodePort or Loadbalancer)
+    nodePort1: 31444
+    # -- NodePort port 2 to allocate on each node (only if service.type = NodePort or Loadbalancer)
+    nodePort2: 31900
+    # -- Annotations for the Zabbix WebDriver
+    annotations: {}
+    # metallb.universe.tf/address-pool: production-public-ips
+  # -- Extra environment variables. A list of additional environment variables. List can be extended with other environment variables listed here: https://www.selenium.dev/documentation/grid/configuration
+  extraEnv: []
+  #  - name: VAR_1
+  #    value: 'example_value'
+  # -- Annotations to add to the deployment
+  extraDeploymentAnnotations: {}
+  # -- Labels to add to the deployment
+  extraDeploymentLabels: {}
+  # -- Annotations to add to the pods
+  extraPodAnnotations: {}
+  # -- Labels to add to the pods
+  extraPodLabels: {}
+  # -- Additional volumeMounts to the Zabbix WebDriver container
+  extraVolumeMounts: []
+  # -- Additional containers to start within the Zabbix WebDriver pod
+  extraContainers: []
+  # -- Additional init containers to start within the Zabbix WebDriver pod
+  extraInitContainers: []
+  # -- Additional volumes to make available to the Zabbix WebDriver pod
+  extraVolumes: []
+  # -- Additional specifications to the Zabbix WebDriver pod
+  extraPodSpecs: {}
+  # -- Security Context configurations. Reference: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  securityContext: {}
+  livenessProbe: {}
+  readinessProbe: {}
+  # -- The kubelet uses startup probes to know when a container application has started.  Reference: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+  startupProbe: {}
   # -- nodeSelector configurations. Reference: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
   nodeSelector: {}
 


### PR DESCRIPTION
#### What this PR does / why we need it:
- Bump version
- Adjust in docs
- Added new values in ``docs/example/kind/values.yaml`` to support 7.4.0 release (but the docker image not exists yet)
- Improvements in deployment and service objects of zabbixBrowserMonitoring
- New env vars (have break changes):

```yaml
zabbixBrowserMonitoring:
  webdriver:
    # -- Number of replicas of ``zabbixWebDriver`` module
    replicaCount: 1
    # -- set permissive podAntiAffinity to spread replicas over cluster nodes if replicaCount>1
    podAntiAffinity: true
    # -- Requests and limits of pod resources. See: [https://kubernetes.io/docs/concepts/configuration/manage-resources-containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers)
    resources: {}
    image:
      # -- WebDriver container image tag, See https://hub.docker.com/r/selenium/standalone-chrome/tags
      tag: 124.0-chromedriver-124.0-grid-4.33.0-20250606
    # -- WebDriver container port 1
    port1: 4444
    # -- WebDriver container port 2
    port2: 7900
  # -- Custom WebDriver URL. If set, it overrides the default internal WebDriver service URL. Set zabbixBrowserMonitoring.webdriver.enabled to false when setting this.
  customWebDriverURL: ""
  service:
    # -- Type of service to expose the application. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer.
    # More details: https://kubernetes.io/docs/concepts/services-networking/service/
    type: ClusterIP
    # -- clusterIP is the IP address of the service and is usually assigned randomly.
    # If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service.
    clusterIP:
    # -- externalTrafficPolicy describes how nodes distribute service traffic they receive on one of the Service's "externally-facing" addresses
    # (NodePorts, ExternalIPs, and LoadBalancer IPs). "Local" to preserve sender's IP address. Please note that this might not work on multi-node clusters,
    # depending on your network settings.
    # externalTrafficPolicy: Local
    # -- externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.
    # These IPs are not managed by Kubernetes.
    externalIPs: []
    # -- Only applies to Service Type: LoadBalancer. This feature depends on whether the underlying cloud-provider supports specifying
    # the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature.
    loadBalancerIP: ""
    # -- If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer
    # will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature.
    loadBalancerSourceRanges: []
    # -- loadBalancerClass is the class of the load balancer implementation this Service belongs to.
    # If specified, the value of this field must be a label-style identifier, with an optional prefix, e.g. "internal-vip" or
    # "example.com/internal-vip". Unprefixed names are reserved for end-users. This field can only be set when the Service type is 'LoadBalancer'.
    # If not set, the default load balancer implementation is used, today this is typically done through the cloud provider integration,
    # but should apply for any default implementation. If set, it is assumed that a load balancer implementation is watching for Services
    # with a matching class. Any default load balancer implementation (e.g. cloud providers) should ignore Services that set this field.
    # This field can only be set when creating or updating a Service to type 'LoadBalancer'. Once set, it can not be changed.
    # This field will be wiped when a service is updated to a non 'LoadBalancer' type.
    loadBalancerClass: ""
    # -- Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity.
    # Must be ClientIP or None. Defaults to None. More info:
    # https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
    sessionAffinity: None  
    # -- Port 1 of service in Kubernetes cluster
    port1: 4444
    # -- Port 2 of service in Kubernetes cluster
    port2: 7900
    # -- NodePort port 1 to allocate on each node (only if service.type = NodePort or Loadbalancer)
    nodePort1: 31444
    # -- NodePort port 2 to allocate on each node (only if service.type = NodePort or Loadbalancer)
    nodePort2: 31900
    # -- Annotations for the Zabbix WebDriver
    annotations: {}
    # metallb.universe.tf/address-pool: production-public-ips
  # -- Extra environment variables. A list of additional environment variables. List can be extended with other environment variables listed here: https://www.selenium.dev/documentation/grid/configuration
  extraEnv: []
  #  - name: VAR_1
  #    value: 'example_value'
  # -- Annotations to add to the deployment
  extraDeploymentAnnotations: {}
  # -- Labels to add to the deployment
  extraDeploymentLabels: {}
  # -- Annotations to add to the pods
  extraPodAnnotations: {}
  # -- Labels to add to the pods
  extraPodLabels: {}
  # -- Additional volumeMounts to the Zabbix WebDriver container
  extraVolumeMounts: []
  # -- Additional containers to start within the Zabbix WebDriver pod
  extraContainers: []
  # -- Additional init containers to start within the Zabbix WebDriver pod
  extraInitContainers: []
  # -- Additional volumes to make available to the Zabbix WebDriver pod
  extraVolumes: []
  # -- Additional specifications to the Zabbix WebDriver pod
  extraPodSpecs: {}
  # -- Security Context configurations. Reference: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
  securityContext: {}
  livenessProbe: {}
  readinessProbe: {}
  # -- The kubelet uses startup probes to know when a container application has started.  Reference: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
  startupProbe: {}
  # -- nodeSelector configurations. Reference: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
  nodeSelector: {}
```

#### Which issue this PR fixes
  - fixes #202 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/zabbix-community/helm-zabbix/blob/main/CONTRIBUTING.md) signed
- [x] Variables are documented in values.yaml with [Helm-Docs](https://github.com/norwoodj/helm-docs) comments, as we build README.md using this utility
