### PR TITLE
Add hostPid and hostIPC mode for zabbixAgent

### DIFF
--- a/charts/zabbix/templates/daemonset-zabbix-agent.yaml
+++ b/charts/zabbix/templates/daemonset-zabbix-agent.yaml
@@ -32,6 +32,8 @@ spec:
         {{- toYaml .Values.zabbixAgent.extraPodLabels | nindent 8 }}
         {{- end }}
     spec:
+      hostPID: {{ .Values.zabbixAgent.daemonSetHostPID }}
+      hostIPC: {{ .Values.zabbixAgent.daemonSetHostIPC }}
       {{- if .Values.zabbixAgent.hostNetwork }}
       hostNetwork: {{ .Values.zabbixAgent.hostNetwork }}
       dnsPolicy: ClusterFirstWithHostNet

--- a/charts/zabbix/values.yaml
+++ b/charts/zabbix/values.yaml
@@ -528,6 +528,10 @@ zabbixAgent:
     # metallb.universe.tf/address-pool: production-public-ips
   # -- set whether zabbix agent / agent2 in DaemonSet mode should use hostNetwork. Usually the right option if using zabbix agent for node monitoring. Only applies if `zabbixAgent.runAsDaemonSet=true`
   hostNetwork: true
+  # -- allows the pod to share the host's IPC namespace in DaemonSet mode (e.g., shared memory)
+  daemonSetHostIPC: false
+  # -- allows the pod to see the processes on the host system in DaemonSet mode
+  daemonSetHostPID: false
   # -- If true, agent pods mounts host / at /host/root
   hostRootFsMount: true
   # -- Extra environment variables. A list of additional environment variables. List can be extended with other environment variables listed here: https://github.com/zabbix/zabbix-docker/tree/7.0/Dockerfiles/agent2/alpine#environment-variables. See example: https://github.com/zabbix-community/helm-zabbix/blob/main/charts/zabbix/docs/example/kind/values.yaml


### PR DESCRIPTION
- allows to make the process and host IPC visible for zabbixAgent which is a very usual requirement when managing zabbixAgents with k8s
- the described function is limited to DaemonSet mode

<!--
Thank you for contributing to this repository. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

- https://github.com/zabbix-community/helm-zabbix/blob/main/CONTRIBUTING.md
- https://github.com/zabbix-community/helm-zabbix/blob/main/charts/zabbix/docs/requirements.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.
-->

#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/zabbix-community/helm-zabbix/blob/main/CONTRIBUTING.md) signed
- [x] Variables are documented in values.yaml with [Helm-Docs](https://github.com/norwoodj/helm-docs) comments, as we build README.md using this utility
