### PR TITLE
MySQL - Database support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 See the [charts/zabbix/README.md](charts/zabbix/README.md) file to learn more about this helm chart or access [Artifact Hub](https://artifacthub.io/packages/helm/zabbix-community/zabbix).
 
-> This Helm chart installs [Zabbix](https://www.zabbix.com) in a Kubernetes cluster. It supports only Postgresql/TimescaleDB as a database backend at this point in time, without any plans to extend database support towards MySQL, MariaDB, etc. Also, this Helm Chart supports [Zabbix Server High Availability](charts/zabbix/#native-zabbix-server-high-availability)
+> This Helm chart installs [Zabbix](https://www.zabbix.com) in a Kubernetes cluster. It supports Postgresql/TimescaleDB as a database backend for production and support for external MySQL and MariaDB. Also, this Helm Chart supports [Zabbix Server High Availability](charts/zabbix/#native-zabbix-server-high-availability)
 
 ## Contributing
 

--- a/charts/zabbix/templates/_helpers.tpl
+++ b/charts/zabbix/templates/_helpers.tpl
@@ -113,13 +113,13 @@ Return the entire logic of setting PostgreSQL access related env vars for the co
 {{- $passwordvar := "DB_PASSWORD" }}
 {{- $dbvar := "DB_DATABASE" }}
 {{- if eq .Values.zabbixDBType "mysql" }}
-{{- $uservar := "MYSQL_USER" }}
-{{- $passwordvar := "MYSQL_PASSWORD" }}
-{{- $dbvar := "MYSQL_DATABASE" }}
+{{- $uservar = "MYSQL_USER" }}
+{{- $passwordvar = "MYSQL_PASSWORD" }}
+{{- $dbvar = "MYSQL_DATABASE" }}
 {{- else }}
-{{- $uservar := "POSTGRES_USER" }}
-{{- $passwordvar := "POSTGRES_PASSWORD" }}
-{{- $dbvar := "POSTGRES_DB" }}
+{{- $uservar = "POSTGRES_USER" }}
+{{- $passwordvar = "POSTGRES_PASSWORD" }}
+{{- $dbvar = "POSTGRES_DB" }}
 {{- end }}
 
 {{- $schemavar := "DB_SERVER_SCHEMA" }}

--- a/charts/zabbix/templates/_helpers.tpl
+++ b/charts/zabbix/templates/_helpers.tpl
@@ -109,6 +109,9 @@ Return the entire logic of setting PostgreSQL access related env vars for the co
 {{- with index . 1 }}
 {{- $hostvar := "DB_SERVER_HOST" }}
 {{- $portvar := "DB_SERVER_PORT" }}
+{{- $uservar := "DB_USER" }}
+{{- $passwordvar := "DB_PASSWORD" }}
+{{- $dbvar := "DB_DATABASE" }}
 {{- if eq .Values.zabbixDBType "mysql" }}
 {{- $uservar := "MYSQL_USER" }}
 {{- $passwordvar := "MYSQL_PASSWORD" }}

--- a/charts/zabbix/templates/_helpers.tpl
+++ b/charts/zabbix/templates/_helpers.tpl
@@ -109,9 +109,16 @@ Return the entire logic of setting PostgreSQL access related env vars for the co
 {{- with index . 1 }}
 {{- $hostvar := "DB_SERVER_HOST" }}
 {{- $portvar := "DB_SERVER_PORT" }}
+{{- if eq .Values.zabbixDBType "mysql" }}
+{{- $uservar := "MYSQL_USER" }}
+{{- $passwordvar := "MYSQL_PASSWORD" }}
+{{- $dbvar := "MYSQL_DATABASE" }}
+{{- else }}
 {{- $uservar := "POSTGRES_USER" }}
 {{- $passwordvar := "POSTGRES_PASSWORD" }}
 {{- $dbvar := "POSTGRES_DB" }}
+{{- end }}
+
 {{- $schemavar := "DB_SERVER_SCHEMA" }}
 {{/* special settings for the DB client (autoclean cron job) container, needs different env variable names */}}
 {{- if eq $cntxt "db_client" }}

--- a/charts/zabbix/templates/deployment-zabbix-server.yaml
+++ b/charts/zabbix/templates/deployment-zabbix-server.yaml
@@ -96,9 +96,9 @@ spec:
           securityContext:
             {{- toYaml .Values.zabbixServer.securityContext | nindent 12 }}
           {{- if .Values.zabbixServer.image.tag }}
-          image: "{{ .Values.zabbixServer.image.repository }}:{{ .Values.zabbixServer.image.tag }}"
+          image: "{{ .Values.zabbixServer.image.repository }}{{ .Values.zabbixDBType }}:{{ .Values.zabbixServer.image.tag }}"
           {{- else }}
-          image: "{{ .Values.zabbixServer.image.repository }}:{{ .Values.zabbixImageTag }}"
+          image: "{{ .Values.zabbixServer.image.repository }}{{ .Values.zabbixDBType }}:{{ .Values.zabbixImageTag }}"
           {{- end }}
           imagePullPolicy: {{ .Values.zabbixServer.image.pullPolicy }}
           ports:

--- a/charts/zabbix/templates/deployment-zabbix-web.yaml
+++ b/charts/zabbix/templates/deployment-zabbix-web.yaml
@@ -70,9 +70,9 @@ spec:
         securityContext:
           {{- toYaml .Values.zabbixWeb.securityContext | nindent 10 }}
         {{- if .Values.zabbixWeb.image.tag }}
-        image: "{{ .Values.zabbixWeb.image.repository }}:{{ .Values.zabbixWeb.image.tag }}"
+        image: "{{ .Values.zabbixWeb.image.repository }}{{ .Values.zabbixDBType }}:{{ .Values.zabbixWeb.image.tag }}"
         {{- else }}
-        image: "{{ .Values.zabbixWeb.image.repository }}:{{ .Values.zabbixImageTag }}"
+        image: "{{ .Values.zabbixWeb.image.repository }}{{ .Values.zabbixDBType }}:{{ .Values.zabbixImageTag }}"
         {{- end }}
         imagePullPolicy: {{ .Values.zabbixWeb.image.pullPolicy }}
         env:

--- a/charts/zabbix/values.yaml
+++ b/charts/zabbix/values.yaml
@@ -22,6 +22,11 @@ global:
 # here or overwrite in each component (example: zabbixserver.image.tag, etc).
 zabbixImageTag: ubuntu-7.0.16
 
+# -- Zabbix components (server and web frontend) DB-type for repository to use.
+# Supported types are:
+#      pgsql, mysql
+zabbixDBType: pgsql
+
 # **Zabbix Postgresql access / credentials** configurations
 # with this dict, you can set unified PostgreSQL access credentials, IP and so on for both Zabbix Server and Zabbix web frontend
 # you can either chose from having all this in one named (preexisting) secret or setting the values one by one with vars
@@ -154,7 +159,7 @@ zabbixServer:
   resources: {}
   image:
     # -- Zabbix Server Docker image name
-    repository: zabbix/zabbix-server-pgsql
+    repository: zabbix/zabbix-server-
     # -- Zabbix Server Docker image tag, if you want to override zabbixImageTag
     tag: null
     # -- Pull policy of Docker image
@@ -590,7 +595,7 @@ zabbixWeb:
   resources: {}
   image:
     # -- Zabbix Web Docker image name
-    repository: zabbix/zabbix-web-nginx-pgsql
+    repository: zabbix/zabbix-web-nginx-
     # -- Zabbix Web Docker image tag, if you want to override zabbixImageTag
     tag: null
     # -- Pull policy of Docker image

--- a/charts/zabbix/values.yaml
+++ b/charts/zabbix/values.yaml
@@ -25,6 +25,9 @@ zabbixImageTag: ubuntu-7.0.16
 # -- Zabbix components (server and web frontend) DB-type for repository to use.
 # Supported types are:
 #      pgsql, mysql
+#      In case of: mysql
+#         Set  postgresql.enabled: false
+#              zabbixServerHA.enabled: false
 zabbixDBType: pgsql
 
 # **Zabbix Postgresql access / credentials** configurations


### PR DESCRIPTION
#### What this PR does / why we need it:
Added support for external MySQL-/Maria-Databasebackend.

#### Which issue this PR fixes
No issue and no fixes.

#### Special notes for your reviewer:
This is quick implementation to support also external MySQL- and Maria-Databasebackends.<br>
(e.g.: like Percona XtraDB-Cluster for MySQL with ProxySQL for DB-Loadbalancing)

Please give me feedback if you are willing to take over changes for this type of external Databasesupport.<br>
In case of positve feedback, it will be good to change the variable-names of the section:<br>
    postgresAccess

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Variables are documented in values.yaml with [Helm-Docs](https://github.com/norwoodj/helm-docs) comments, as we build README.md using this utility
