### PR TITLE
Add support for dynamic agent hostname using ZBX_HOSTNAMEITEM

### DIFF
--- a/charts/zabbix/templates/daemonset-zabbix-agent.yaml
+++ b/charts/zabbix/templates/daemonset-zabbix-agent.yaml
@@ -83,10 +83,15 @@ spec:
           securityContext:
             {{- toYaml .Values.zabbixAgent.securityContext | nindent 12 }}
           env:
+            {{- if .Values.zabbixAgent.ZBX_HOSTNAMEITEM }}
+            - name: ZBX_HOSTNAMEITEM
+              value: {{ .Values.zabbixAgent.ZBX_HOSTNAMEITEM | quote }}
+            {{- else }}
             - name: ZBX_HOSTNAME
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            {{- end }}
             - name: ZBX_SERVER_HOST
               value: {{ .Values.zabbixAgent.ZBX_SERVER_HOST | quote }}
             - name: ZBX_SERVER_PORT

--- a/charts/zabbix/values.yaml
+++ b/charts/zabbix/values.yaml
@@ -486,6 +486,8 @@ zabbixAgent:
   ZBX_DEBUGLEVEL: 3
   # -- The variable is used to specify timeout for processing checks. By default, value is 4.
   ZBX_TIMEOUT: 4
+  # -- If set, this item will be used to dynamically determine the agent hostname instead of using the Kubernetes node name. Example: "system.hostname"
+  # ZBX_HOSTNAMEITEM: "system.hostname"
   service:
     # -- Type of service to expose the application. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer.
     # More details: https://kubernetes.io/docs/concepts/services-networking/service/


### PR DESCRIPTION
<!--
Thank you for contributing to this repository. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

- https://github.com/zabbix-community/helm-zabbix/blob/main/CONTRIBUTING.md
- https://github.com/zabbix-community/helm-zabbix/blob/main/charts/zabbix/docs/requirements.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.
-->

#### What this PR does / why we need it:

Adds optional support for using `ZBX_HOSTNAMEITEM` in the Zabbix Agent Helm chart. This allows the agent hostname to be derived from a Zabbix item (for example `system.hostname`) instead of always relying on the Kubernetes node name.

The default behavior remains unchanged: `ZBX_HOSTNAME` is still set from `spec.nodeName` if no `ZBX_HOSTNAMEITEM` is configured. This keeps full backward compatibility.

This is useful in environments where the Kubernetes node name is not stable, not meaningful, or abstracted (e.g. managed Kubernetes platforms).

#### Special notes for your reviewer:

This change is intentionally minimal and fully backward compatible. 

Behavior:
- If `ZBX_HOSTNAMEITEM` is set, `ZBX_HOSTNAMEITEM` is used
- Otherwise → `ZBX_HOSTNAME` is set from `spec.nodeName`

Only one of the two environment variables is ever set to avoid conflicts in the Zabbix Agent.

No changes to existing defaults or user-facing behavior unless explicitly configured.

Example configuration:

```yaml
zabbixAgent:
  ZBX_HOSTNAMEITEM: "system.hostname"
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/zabbix-community/helm-zabbix/blob/main/CONTRIBUTING.md) signed
- [x] Variables are documented in values.yaml with [Helm-Docs](https://github.com/norwoodj/helm-docs) comments, as we build README.md using this utility
