### PR TITLE
Publish helm chart as OCI package

### DIFF
--- a/.github/workflows/helm-chart-oci-publish.yml
+++ b/.github/workflows/helm-chart-oci-publish.yml
@@ -1,0 +1,51 @@
+name: Publish Chart to OCI (ghcr.io)
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  release-oci:
+    permissions:
+      contents: read
+      packages: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.13.2
+
+      - name: Extract chart version
+        id: chart_meta
+        run: |
+          CHART_VERSION=$(grep '^version:' charts/zabbix/Chart.yaml | awk '{print $2}')
+          echo "chart_version=${CHART_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GitHub Container Registry
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" \
+            | helm registry login ghcr.io \
+                --username "${{ github.actor }}" \
+                --password-stdin
+
+      - name: Package Helm chart
+        run: helm package charts/zabbix --destination /tmp/helm-packages
+
+      - name: Push chart to ghcr.io
+        run: |
+          helm push \
+            /tmp/helm-packages/zabbix-${{ steps.chart_meta.outputs.chart_version }}.tgz \
+            oci://ghcr.io/${{ github.repository_owner }}
+
+      - name: Verify push
+        run: |
+          helm show chart \
+            oci://ghcr.io/${{ github.repository_owner }}/zabbix \
+            --version ${{ steps.chart_meta.outputs.chart_version }}


### PR DESCRIPTION
#### What this PR does / why we need it:

To simplify software intake we can publish this chart as an OCI package, rather than rely on clusters having direct internet access to GitHub to fetch the helm manifests.
Organizations usually have a way to mirror or pull images and OCI packages from dockerhub as well as GHCR to internal repositories, which can then be consumed.

#### Which issue this PR fixes

I didn't create an issue since I filed this PR

#### Special notes for your reviewer:

Currently there's no docs added to README that the package is published to ghcr, this is not by accident. We'll want to test the flow by doing a release (new tag) to make sure the workflow runs as expected and the necessary secrets are setup in the repo. As well as marking the package as public and linking it to the GitHub repo

* https://docs.github.com/en/packages/learn-github-packages/configuring-a-packages-access-control-and-visibility#configuring-access-to-packages-for-an-organization
* https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package#connecting-a-repository-to-an-organization-scoped-package-on-github

#### Checklist
- [x] [DCO](https://github.com/zabbix-community/helm-zabbix/blob/main/CONTRIBUTING.md) signed