### PR TITLE
fix: extra env nindent from 14 to 12 in ha node cleanup job

### DIFF
--- a/charts/zabbix/templates/cronjob-hanodes-autoclean.yaml
+++ b/charts/zabbix/templates/cronjob-hanodes-autoclean.yaml
@@ -48,7 +48,7 @@ spec:
             env:
             {{- include "zabbix.postgresAccess.variables" (list $ . "db_client") | nindent 12 }}
             {{- with .Values.zabbixServer.haNodesAutoClean.extraEnv }}
-              {{- toYaml . | nindent 14 }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
             {{- with .Values.zabbixServer.haNodesAutoClean.extraVolumeMounts }}
             volumeMounts:


### PR DESCRIPTION
#### What this PR does / why we need it:
Fixes an indentation bug in the HA node cleanup job template. The `extraEnv`
block was rendered with `indent 14`, while the surrounding env variables
(including those from `postgresAccess`) use `indent 12`. As a result, the
extra env variables were emitted with 2 extra spaces of indentation, producing
misaligned YAML in the generated manifest. This aligns `extraEnv` to `indent 12`
so it matches the rest of the env block.

Verified with `helm template`: before the fix the `extraEnv` entries appear
indented 2 spaces deeper than the neighboring variables; after the fix they line
up correctly under the `env:` list.

